### PR TITLE
Added scripts for Keep Dashboard installation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -132,6 +132,13 @@ end-to-end tests. Before you start interacting, make sure you:
 - Have a working relay maintainer (`run-testnet-relay.sh`)
 - Have 1 `keep-core` and 3 `keep-ecdsa` clients up and running
 
+== Keep Dashboard dApp
+
+To run the Keep Dashboard dApp invoke:
+```
+./run-keep-dashboard.sh
+```
+
 == tBTC dApp
 
 To run the tBtc dApp invoke:

--- a/install-keep-dashboard.sh
+++ b/install-keep-dashboard.sh
@@ -21,6 +21,11 @@ printf "${LOG_START}Preparing keep-ecdsa artifacts...${LOG_END}"
 cd $WORKDIR/keep-ecdsa/solidity
 ln -sf build/contracts artifacts
 
+printf "${LOG_START}Preparing tBTC artifacts...${LOG_END}"
+
+cd $WORKDIR/tbtc/solidity
+ln -sf build/contracts artifacts
+
 printf "${LOG_START}Install Keep Dashboard dependencies...${LOG_END}"
 
 cd $WORKDIR/keep-core/solidity/dashboard

--- a/install-keep-dashboard.sh
+++ b/install-keep-dashboard.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+set -e
+
+LOG_START='\n\e[1;36m' # new line + bold + color
+LOG_END='\n\e[0m' # new line + reset color
+DONE_START='\n\e[1;32m' # new line + bold + green
+DONE_END='\n\n\e[0m'    # new line + reset
+
+WORKDIR=$PWD
+
+printf "${LOG_START}Starting Keep Dashboard deployment...${LOG_END}"
+
+printf "${LOG_START}Preparing keep-core artifacts...${LOG_END}"
+
+cd $WORKDIR/keep-core/solidity
+ln -sf build/contracts artifacts
+
+printf "${LOG_START}Preparing keep-ecdsa artifacts...${LOG_END}"
+
+cd $WORKDIR/keep-ecdsa/solidity
+ln -sf build/contracts artifacts
+
+printf "${LOG_START}Install Keep Dashboard dependencies...${LOG_END}"
+
+cd $WORKDIR/keep-core/solidity/dashboard
+
+npm install
+
+printf "${LOG_START}Updating Keep Dashboard dependnecies...${LOG_END}"
+
+cd $WORKDIR/keep-core/solidity
+npm link
+
+cd $WORKDIR/keep-ecdsa/solidity
+npm link
+
+cd $WORKDIR/tbtc/solidity
+npm link
+
+printf "${LOG_START}Updating Keep Dashboard configuration...${LOG_END}"
+
+cd $WORKDIR/keep-core/solidity/dashboard
+npm link @keep-network/keep-core
+npm link @keep-network/keep-ecdsa
+npm link @keep-network/tbtc
+
+printf "${DONE_START}Keep Dashboard initialized successfully!${DONE_END}"

--- a/install.sh
+++ b/install.sh
@@ -14,6 +14,9 @@ set -e
 # Install tBTC.
 ./install-tbtc.sh
 
+# Install Keep Dashboard.
+./install-keep-dashboard.sh
+
 # Install tBTC dApp.
 ./install-tbtc-dapp.sh
 

--- a/run-keep-dashboard.sh
+++ b/run-keep-dashboard.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+LOG_START='\n\e[1;36m' # new line + bold + color
+LOG_END='\n\e[0m' # new line + reset color
+DONE_START='\n\e[1;32m' # new line + bold + green
+DONE_END='\n\n\e[0m'    # new line + reset
+
+WORKDIR=$PWD
+
+printf "${LOG_START}Starting Keep Dashboard...${LOG_END}"
+
+cd $WORKDIR/keep-core/solidity/dashboard
+
+npm run start


### PR DESCRIPTION
The scripts can be used for Keep Dashboard installation and run.
To install the dashboard execute: `./install-keep-dashboard.sh`
To run the dasbhoard execute `./run-keep-dashboard.sh`

The install script is also a part of main `install.sh` and is executed after tBTC installation.