### PR TITLE
Testnet-ready end-to-end test script

### DIFF
--- a/bitcoin/bitcoind/Dockerfile
+++ b/bitcoin/bitcoind/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04
 
-RUN apt-get update && apt-get install -y wget && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y wget jq && rm -rf /var/lib/apt/lists/*
 
 RUN wget -O bitcoin-core.tar.gz https://bitcoin.org/bin/bitcoin-core-0.20.0/bitcoin-0.20.0-x86_64-linux-gnu.tar.gz
 RUN mkdir /bitcoin-core && tar -xzf bitcoin-core.tar.gz -C /bitcoin-core --strip-components=1

--- a/bitcoin/bitcoind/entrypoint.sh
+++ b/bitcoin/bitcoind/entrypoint.sh
@@ -20,8 +20,13 @@ sleep 10
 
 alias btccli='./bitcoin-cli -regtest -datadir=datadir -rpcport=18332 -rpcuser=user -rpcpassword=password'
 
-# Get an address.
-address=$(btccli getnewaddress)
+# Use a specific private key.
+privateKey="cTj6Z9fxMr4pzfpUhiN8KssVzZjgQz9zFCfh87UrH8ZLjh3hGZKF"
+
+btccli importprivkey "$privateKey" "main"
+
+# Get the imported address. It should start with `bcrt1` because this is the right prefix for the regtest network.
+address=$(btccli getaddressesbylabel "main" | jq -r 'with_entries(select(.key | startswith("bcrt1"))) | 'keys[0]'')
 
 # Mine some initial blocks to unlock coinbase.
 btccli generatetoaddress 1000 "$address"

--- a/bitcoin/docker-compose.yml
+++ b/bitcoin/docker-compose.yml
@@ -19,4 +19,6 @@ services:
       - COIN=BitcoinSegwit
       - NET=regtest
       - SERVICES=tcp://0.0.0.0:50001,ssl://0.0.0.0:50002,ws://0.0.0.0:50003,wss://127.0.0.1:50004,rpc://0.0.0.0:8000
+      - COST_SOFT_LIMIT=0
+      - COST_HARD_LIMIT=0
     build: ./electrumx

--- a/deployments/e2e-test/e2e-test-configmap.yml
+++ b/deployments/e2e-test/e2e-test-configmap.yml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: e2e-test-config
+  namespace: default
+data:
+  bitcoin-electrum-host: "34.70.251.19"
+  bitcoin-electrum-port: "8080"
+  bitcoin-network: "testnet"
+  ethereum-node: "wss://ropsten.infura.io/ws/v3/880f2a054e784898a55627bd5f047917"

--- a/deployments/e2e-test/e2e-test-cronjob.yaml
+++ b/deployments/e2e-test/e2e-test-cronjob.yaml
@@ -1,0 +1,64 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: e2e-test
+  namespace: default
+  labels:
+    app: tbtc
+    type: e2e-test
+spec:
+  schedule: '0 */4 * * *'
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    metadata:
+      labels:
+        app: tbtc
+        type: e2e-test
+    spec:
+      backoffLimit: 0
+      activeDeadlineSeconds: 3600
+      template:
+        spec:
+          containers:
+          - name: e2e-test
+            image: gcr.io/keep-test-f3e0/e2e-test
+            args: [
+              "--bitcoin-electrum-host", "$(BITCOIN_ELECTRUM_HOST)",
+              "--bitcoin-electrum-port", "$(BITCOIN_ELECTRUM_PORT)",
+              "--bitcoin-network", "$(BITCOIN_NETWORK)",
+              "--bitcoin-depositor-pk", "$(BITCOIN_DEPOSITOR_PK)",
+              "--ethereum-node", "$(ETHEREUM_NODE)",
+              "--ethereum-pk", "$(ETHEREUM_PK)"
+            ]
+            env:
+              - name: BITCOIN_ELECTRUM_HOST
+                valueFrom:
+                  configMapKeyRef:
+                    name: e2e-test-config
+                    key: bitcoin-electrum-host
+              - name: BITCOIN_ELECTRUM_PORT
+                valueFrom:
+                  configMapKeyRef:
+                    name: e2e-test-config
+                    key: bitcoin-electrum-port
+              - name: BITCOIN_NETWORK
+                valueFrom:
+                  configMapKeyRef:
+                    name: e2e-test-config
+                    key: bitcoin-network
+              - name: BITCOIN_DEPOSITOR_PK
+                valueFrom:
+                  secretKeyRef:
+                    name: e2e-test-secret
+                    key: bitcoin-depositor-pk
+              - name: ETHEREUM_NODE
+                valueFrom:
+                  configMapKeyRef:
+                    name: e2e-test-config
+                    key: ethereum-node
+              - name: ETHEREUM_PK
+                valueFrom:
+                  secretKeyRef:
+                    name: e2e-test-secret
+                    key: ethereum-pk
+          restartPolicy: Never

--- a/deployments/e2e-test/e2e-test-secret.yml.SAMPLE
+++ b/deployments/e2e-test/e2e-test-secret.yml.SAMPLE
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: e2e-test-secret
+  namespace: default
+type: Opaque
+data:
+  bitcoin-depositor-pk: "base64 encoded Bitcoin depositor private key WIF"
+  ethereum-pk: "base64 encoded Ethereum account private key"

--- a/e2e/.dockerignore
+++ b/e2e/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -1,0 +1,22 @@
+FROM node:14.3.0-alpine3.11
+
+ENV TBTCJS_VERSION 0.17.0-rc.1
+
+RUN apk add --no-cache \
+    jq \
+    git \
+    python3 \
+    build-base
+
+WORKDIR /e2e
+
+COPY . .
+
+RUN jq '.dependencies."@keep-network/tbtc.js" = env.TBTCJS_VERSION' \
+    package.json > package.json.tmp && mv package.json.tmp package.json
+
+RUN npm install
+
+ENTRYPOINT ["node", "--experimental-json-modules", "e2e-test.js"]
+
+CMD []

--- a/e2e/assertions.js
+++ b/e2e/assertions.js
@@ -1,4 +1,4 @@
-import {getTBTCTokenBalance, getReceivedBtcAmount} from "./common.js";
+import {getTBTCTokenBalance, getBtcBalance} from "./common.js";
 
 export const assertMintedTbtcAmount = (web3, deposit, expectedTbtcAmount) => {
     const actualTbtcAmountBn = web3.utils.toBN(deposit.tbtcAmount)
@@ -31,18 +31,20 @@ export const assertTbtcAccountBalance = async (
     }
 }
 
-export const assertReceivedBtcAmount = async (
-    bitcoinRpc,
+export const assertBtcBalance = async (
+    web3,
+    BitcoinHelpers,
     address,
-    expectedReceivedBtcAmount
+    expectedBtcBalance
 ) => {
-    const actualReceivedBtcAmount = await getReceivedBtcAmount(bitcoinRpc, address)
+    const actualBtcBalanceBn = await getBtcBalance(web3, BitcoinHelpers, address)
+    const expectedBtcBalanceBn = web3.utils.toBN(expectedBtcBalance)
 
-    if (actualReceivedBtcAmount !== expectedReceivedBtcAmount) {
+    if (!actualBtcBalanceBn.eq(expectedBtcBalanceBn)) {
         throw new Error(
-            `unexpected received BTC amount for address ${address}:
-                actual:   ${actualReceivedBtcAmount}
-                expected: ${expectedReceivedBtcAmount}`
+            `unexpected BTC balance for address ${address}:
+                actual:   ${actualBtcBalanceBn}
+                expected: ${expectedBtcBalanceBn}`
         )
     }
 }

--- a/e2e/common.js
+++ b/e2e/common.js
@@ -11,3 +11,121 @@ export const getBtcBalance = async (web3, BitcoinHelpers, address) => {
 
     return web3.utils.toBN(balance)
 }
+
+export const importBitcoinPrivateKey = async (
+    bcoin,
+    wif,
+    wallet, privateKey
+) => {
+    const decodedPrivateKey = wif.decode(privateKey);
+
+    const keyRing = new bcoin.KeyRing({
+        witness: true,
+        privateKey: decodedPrivateKey.privateKey,
+        compressed: decodedPrivateKey.compressed
+    });
+
+    await wallet.importKey(0, keyRing)
+
+    return keyRing
+}
+
+export const generateBitcoinPrivateKey = async (bcoin, wallet) => {
+    const keyRing = bcoin.KeyRing.generate(true)
+    keyRing.witness = true
+
+    await wallet.importKey(0, keyRing)
+
+    return keyRing
+}
+
+export const sendBitcoinTransaction = async(
+    bcoin,
+    BitcoinHelpers,
+    targetAddress,
+    amount,
+    keyRing,
+    subtractFee = false
+) => {
+    const sourceAddress = keyRing.getAddress("string");
+
+    console.log(`Sending transaction from ${sourceAddress} to ${targetAddress}`)
+
+    const utxos = await BitcoinHelpers.Transaction.findAllUnspent(sourceAddress)
+
+    const coins = []
+    let coinsAmount = 0
+
+    // Start from the oldest UTXO.
+    for (const utxo of utxos.reverse()) {
+        // Make sure the selected coins amount covers the 110% of the amount.
+        // The additional 10% is taken as a big reserve to make sure that input
+        // coins will cover the transaction fee.
+        if (coinsAmount >= 1.1 * amount.toNumber()) {
+            break
+        }
+
+        const tx = await BitcoinHelpers.withElectrumClient(async electrumClient => {
+            return electrumClient.getTransaction(utxo.transactionID)
+        })
+
+        coins.push(bcoin.Coin.fromTX(
+            bcoin.MTX.fromRaw(tx.hex, 'hex'),
+            utxo.outputPosition,
+            -1
+        ))
+
+        coinsAmount += utxo.value
+    }
+
+    const transaction = new bcoin.MTX()
+
+    transaction.addOutput({
+        script: bcoin.Script.fromAddress(targetAddress),
+        value: amount.toNumber(),
+    })
+
+    await transaction.fund(
+        coins,
+        {
+            rate: null, // set null explicitly to always use the default value
+            changeAddress: sourceAddress,
+            subtractFee: subtractFee
+        }
+    )
+
+    transaction.sign(keyRing)
+
+    const broadcastOutcome = await BitcoinHelpers.Transaction.broadcast(
+        transaction.toRaw().toString('hex')
+    )
+
+    console.log(`Transaction ${broadcastOutcome.transactionID} sent`)
+}
+
+export const returnBitcoinToDepositor = async (
+    web3,
+    bcoin,
+    BitcoinHelpers,
+    depositorKeyRing,
+    redeemerKeyRing
+) => {
+    const redeemerBalance = await getBtcBalance(
+        web3,
+        BitcoinHelpers,
+        redeemerKeyRing.getAddress("string")
+    )
+
+    const depositorAddress = depositorKeyRing.getAddress("string")
+
+    console.log(`Returning ${redeemerBalance} satoshis to depositor ${depositorAddress}`)
+
+    await sendBitcoinTransaction(
+        bcoin,
+        BitcoinHelpers,
+        depositorAddress,
+        redeemerBalance,
+        redeemerKeyRing,
+        true
+    )
+}

--- a/e2e/common.js
+++ b/e2e/common.js
@@ -6,16 +6,8 @@ export const getTBTCTokenBalance = async (web3, tbtc, account) => {
     return web3.utils.toBN(balance)
 }
 
-export const getReceivedBtcAmount = async (bitcoinRpc, address) => {
-    const received = (await bitcoinRpc.listreceivedbyaddressAsync(1, false, true, address)).result
+export const getBtcBalance = async (web3, BitcoinHelpers, address) => {
+    const balance = await BitcoinHelpers.Transaction.getBalance(address);
 
-    let receivedBtcAmount = 0
-
-    for (let i = 0; i < received.length; i++) {
-        if (received[i].address === address) {
-            receivedBtcAmount += received[i].amount
-        }
-    }
-
-    return receivedBtcAmount
+    return web3.utils.toBN(balance)
 }

--- a/e2e/e2e-test.js
+++ b/e2e/e2e-test.js
@@ -15,7 +15,6 @@ const bitcoinElectrumHost = "127.0.0.1"
 const bitcoinElectrumPort = 50003
 const bitcoinNetwork = "regtest"
 const bitcoinDepositorPrivateKey = "cTj6Z9fxMr4pzfpUhiN8KssVzZjgQz9zFCfh87UrH8ZLjh3hGZKF"
-const bitcoinRedeemerPrivateKey = "cPvsaHbYdoPDTrPymWwxAhahz9cRT75Mp6bcQPnP6JyccN4qrTif"
 
 const ethereumHost = "127.0.0.1"
 const ethereumPort = 8546
@@ -70,11 +69,7 @@ async function run() {
 
     )
 
-    // TODO: Try to generate a new address for each redemption.
-    const bitcoinRedeemerKeyRing = await importBitcoinPrivateKey(
-        bitcoinWallet,
-        bitcoinRedeemerPrivateKey
-    )
+    const bitcoinRedeemerKeyRing = await generateBitcoinPrivateKey(bitcoinWallet)
 
     const initialTbtcAccountBalance = await getTBTCTokenBalance(
         web3,
@@ -216,6 +211,15 @@ async function importBitcoinPrivateKey(wallet, privateKey) {
         privateKey: decodedPrivateKey.privateKey,
         compressed: decodedPrivateKey.compressed
     });
+
+    await wallet.importKey(0, keyRing)
+
+    return keyRing
+}
+
+async function generateBitcoinPrivateKey(wallet) {
+    const keyRing = bcoin.KeyRing.generate(true)
+    keyRing.witness = true
 
     await wallet.importKey(0, keyRing)
 

--- a/e2e/e2e-test.js
+++ b/e2e/e2e-test.js
@@ -248,7 +248,7 @@ async function sendBitcoinTransaction(
 
     console.log(`Sending transaction from ${sourceAddress} to ${targetAddress}`)
 
-    const utxos = await BitcoinHelpers.Transaction.findAll(sourceAddress)
+    const utxos = await BitcoinHelpers.Transaction.findAllUnspent(sourceAddress)
 
     const coins = []
     let coinsAmount = 0
@@ -282,15 +282,10 @@ async function sendBitcoinTransaction(
         value: amount.toNumber(),
     })
 
-
-    const rate = await estimateBitcoinTransactionRate();
-
-    console.log(`Using transaction rate: ${rate}`)
-
     await transaction.fund(
         coins,
         {
-            rate: rate,
+            rate: null, // set null explicitly to always use the default value
             changeAddress: sourceAddress,
             subtractFee: subtractFee
         }
@@ -303,14 +298,6 @@ async function sendBitcoinTransaction(
     )
 
     console.log(`Transaction ${broadcastOutcome.transactionID} sent`)
-}
-
-async function estimateBitcoinTransactionRate() {
-    try {
-        return await BitcoinHelpers.Transaction.estimateFeePerKb()
-    } catch (e) {
-        return null
-    }
 }
 
 async function returnBitcoinToDepositor(depositorKeyRing, redeemerKeyRing) {

--- a/e2e/e2e-test.js
+++ b/e2e/e2e-test.js
@@ -17,8 +17,7 @@ program
     .option('--bitcoin-electrum-port <port>', "electrum server port", (port) => parseInt(port, 10), 50003)
     .option('--bitcoin-network <network>', "type of the bitcoin network (\"regtest\"|\"testnet\")", "regtest")
     .option('--bitcoin-depositor-pk <privateKey>', "private key of the Bitcoin depositor in WIF format", "cTj6Z9fxMr4pzfpUhiN8KssVzZjgQz9zFCfh87UrH8ZLjh3hGZKF")
-    .option('--ethereum-host <host>', "ethereum node host", "127.0.0.1")
-    .option('--ethereum-port <port>', "ethereum node port", (port) => parseInt(port, 10), 8546)
+    .option('--ethereum-node <url>', "ethereum node url", "ws://127.0.0.1:8546")
     .option('--ethereum-pk <privateKey>', "private key of ethereum account", "f95e1da038f1fd240cb0c966d8826fb5c0369407f76f34736a5c381da7ca0ecd")
     .parse(process.argv)
 
@@ -40,9 +39,7 @@ engine.addProvider(
     new Subproviders.PrivateKeyWalletSubprovider(program.ethereumPk)
 )
 engine.addProvider(
-    new WebsocketSubprovider({
-        rpcUrl: `ws://${program.ethereumHost}:${program.ethereumPort}`
-    })
+    new WebsocketSubprovider({rpcUrl: program.ethereumNode})
 )
 
 const web3 = new Web3(engine)

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -8,6 +8,7 @@
     "web3": "1.2.8",
     "web3-provider-engine": "15.0.12",
     "bcoin": "git+https://github.com/bcoin-org/bcoin.git#8851582",
-    "wif": "2.0.6"
+    "wif": "2.0.6",
+    "commander": "6.0.0"
   }
 }

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -7,7 +7,7 @@
     "@0x/subproviders": "6.0.8",
     "web3": "1.2.8",
     "web3-provider-engine": "15.0.12",
-    "bitcoind-rpc": "0.8.1",
-    "bluebird": "3.7.2"
+    "bcoin": "git+https://github.com/bcoin-org/bcoin.git#8851582",
+    "wif": "2.0.6"
   }
 }


### PR DESCRIPTION
Refs: https://github.com/keep-network/tbtc/issues/703
<s>Depends on: https://github.com/keep-network/tbtc.js/pull/58</s>

Here we modify the `e2e-test.js` script to enable the interaction with Keep testnet.

**Summary**
- Got rid of the direct dependency on Bitcoin RPC and stick to ElectrumX + bcoin library. This increases portability and allows us to run the script against both `local-setup` instances and testnet.
- Introduced manual construction of deposit transactions instead of use RPC's `sendtoaddress`. This opens new customization capabilities for future (e.g. test different types of transactions)
- Aligned `local-setup` scripts to keep the current functionality
- Externalized the configuration to command line parameters
- Introduced a `Dockerfile` which allows to build and run `e2e-test.js` independently against an arbitrary environment and avoid the installation of a `local-setup` instance 
- Introduced the k8s cron job config (`deployments/e2e-test`) to continuously execute the e2e test script against the testnet 