### PR TITLE
Symlink local keep-ecdsa artifacts for tBTC

### DIFF
--- a/install-tbtc-dapp.sh
+++ b/install-tbtc-dapp.sh
@@ -11,18 +11,10 @@ WORKDIR=$PWD
 
 printf "${LOG_START}Starting tBTC dApp deployment...${LOG_END}"
 
-printf "${LOG_START}Preparing keep-ecdsa artifacts...${LOG_END}"
-
-cd $WORKDIR/keep-ecdsa
-
-cd solidity
-ln -sf build/contracts artifacts
-
 printf "${LOG_START}Preparing tbtc artifacts...${LOG_END}"
 
-cd $WORKDIR/tbtc
+cd "$WORKDIR/tbtc/solidity"
 
-cd solidity
 ln -sf build/contracts artifacts
 
 printf "${LOG_START}Updating tbtc.js configuration...${LOG_END}"

--- a/install-tbtc.sh
+++ b/install-tbtc.sh
@@ -39,10 +39,18 @@ if [ "$BTC_NETWORK" == "testnet" ]; then
   jq '.init.bitcoinTest |= fromjson' relay-config.json > relay-config.json.tmp && mv relay-config.json.tmp relay-config.json
 fi
 
+printf "${LOG_START}Running install script...${LOG_END}"
+
 cd "$WORKDIR/tbtc"
 
 # Run tBTC install script.  Answer with ENTER on emerging prompt.
 printf '\n' | ./scripts/install.sh
+
+printf "${LOG_START}Updating tBTC node_modules...${LOG_END}"
+
+cd $WORKDIR
+rm -rf tbtc/solidity/node_modules/@keep-network/keep-ecdsa
+cp -R keep-ecdsa/solidity/. tbtc/solidity/node_modules/@keep-network/keep-ecdsa
 
 cd "$WORKDIR/tbtc/solidity"
 

--- a/install-tbtc.sh
+++ b/install-tbtc.sh
@@ -20,10 +20,10 @@ done
 
 printf "${LOG_START}Starting tBTC deployment...${LOG_END}"
 
+printf "${LOG_START}Using $BTC_NETWORK Bitcoin network${LOG_END}"
+
 cd "$WORKDIR/relay-genesis"
 npm install
-
-printf "${LOG_START}Using $BTC_NETWORK Bitcoin network${LOG_END}"
 
 if [ "$BTC_NETWORK" == "testnet" ]; then
   # Deploy TestnetRelay instead of the defaull MockRelay.
@@ -39,11 +39,17 @@ if [ "$BTC_NETWORK" == "testnet" ]; then
   jq '.init.bitcoinTest |= fromjson' relay-config.json > relay-config.json.tmp && mv relay-config.json.tmp relay-config.json
 fi
 
-printf "${LOG_START}Updating tBTC node_modules...${LOG_END}"
+printf "${LOG_START}Preparing keep-ecdsa artifacts...${LOG_END}"
 
-cd $WORKDIR
-rm -rf tbtc/solidity/node_modules/@keep-network/keep-ecdsa
-cp -R keep-ecdsa/solidity/. tbtc/solidity/node_modules/@keep-network/keep-ecdsa
+cd "$WORKDIR/keep-ecdsa/solidity"
+
+ln -sf build/contracts artifacts
+
+printf "${LOG_START}Updating tBTC configuration...${LOG_END}"
+
+cd "$WORKDIR/tbtc/solidity"
+
+KEEP_ECDSA_DIR="$WORKDIR/keep-ecdsa/solidity" jq '.dependencies."@keep-network/keep-ecdsa" = env.KEEP_ECDSA_DIR' package.json > package.json.tmp && mv package.json.tmp package.json
 
 printf "${LOG_START}Running install script...${LOG_END}"
 

--- a/install-tbtc.sh
+++ b/install-tbtc.sh
@@ -39,18 +39,18 @@ if [ "$BTC_NETWORK" == "testnet" ]; then
   jq '.init.bitcoinTest |= fromjson' relay-config.json > relay-config.json.tmp && mv relay-config.json.tmp relay-config.json
 fi
 
+printf "${LOG_START}Updating tBTC node_modules...${LOG_END}"
+
+cd $WORKDIR
+rm -rf tbtc/solidity/node_modules/@keep-network/keep-ecdsa
+cp -R keep-ecdsa/solidity/. tbtc/solidity/node_modules/@keep-network/keep-ecdsa
+
 printf "${LOG_START}Running install script...${LOG_END}"
 
 cd "$WORKDIR/tbtc"
 
 # Run tBTC install script.  Answer with ENTER on emerging prompt.
 printf '\n' | ./scripts/install.sh
-
-printf "${LOG_START}Updating tBTC node_modules...${LOG_END}"
-
-cd $WORKDIR
-rm -rf tbtc/solidity/node_modules/@keep-network/keep-ecdsa
-cp -R keep-ecdsa/solidity/. tbtc/solidity/node_modules/@keep-network/keep-ecdsa
 
 cd "$WORKDIR/tbtc/solidity"
 


### PR DESCRIPTION
Changes made by https://github.com/keep-network/tbtc/pull/715 caused fails of the `install-tbtc.sh` script. This is because that pull request introduced a direct dependency on `keep-ecdsa` artifact from within `tbtc` contract migrations scripts. To repair the problem, a symlink to `keep-ecdsa` artifacts should be created before `tbtc` install script execution and the `package.json` file should point to the local `keep-ecdsa` instance.