### PR TITLE
E2E script updates

### DIFF
--- a/e2e/e2e-test.js
+++ b/e2e/e2e-test.js
@@ -197,7 +197,7 @@ async function createDeposit(tbtc, satoshiLotSize, keyRing) {
     return new Promise(async (resolve, reject) => {
         deposit.onBitcoinAddressAvailable(async address => {
             try {
-                const lotSize = await deposit.getSatoshiLotSize()
+                const lotSize = await deposit.getLotSizeSatoshis()
                 console.log(
                     "\tGot deposit address:",
                     address,

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -522,8 +522,8 @@
         "@keep-network/keep-ecdsa": {
           "version": "file:../keep-ecdsa/solidity",
           "requires": {
-            "@keep-network/keep-core": "1.1.2",
-            "@keep-network/sortition-pools": "1.0.0",
+            "@keep-network/keep-core": ">1.3.0-pre <1.3.0-rc",
+            "@keep-network/sortition-pools": "1.1.0",
             "@openzeppelin/upgrades": "^2.7.2",
             "openzeppelin-solidity": "2.3.0",
             "solidity-bytes-utils": "0.0.7"
@@ -664,7 +664,7 @@
               "integrity": "sha512-90hiq6/VqtQgX8Sp0EzeIsv3r+ellbGj4URKj5j30tLlZvRUpnAe9YbYnjl3pJM93GyXU0tghHhvXHq+5rnCKA=="
             },
             "@web3-js/scrypt-shim": {
-              "version": "0.1.0",
+              "version": "github:web3-js/scrypt-shim",
               "from": "github:web3-js/scrypt-shim",
               "requires": {
                 "scryptsy": "^2.1.0",
@@ -4354,7 +4354,7 @@
               },
               "dependencies": {
                 "bignumber.js": {
-                  "version": "2.0.7",
+                  "version": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
                   "from": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
                 },
                 "utf8": {
@@ -4838,7 +4838,7 @@
               },
               "dependencies": {
                 "bignumber.js": {
-                  "version": "2.0.7",
+                  "version": "git+https://github.com/debris/bignumber.js.git#master",
                   "from": "git+https://github.com/debris/bignumber.js.git#master"
                 },
                 "ethereum-common": {
@@ -4971,7 +4971,7 @@
               }
             },
             "websocket": {
-              "version": "1.0.29",
+              "version": "github:web3-js/WebSocket-Node#polyfill/globalThis",
               "from": "github:web3-js/WebSocket-Node#polyfill/globalThis",
               "requires": {
                 "debug": "^2.2.0",
@@ -5167,9 +5167,9 @@
         "@keep-network/tbtc": {
           "version": "file:../tbtc/solidity",
           "requires": {
-            "@keep-network/keep-ecdsa": ">0.15.0-pre <0.15.0-rc",
-            "@summa-tx/bitcoin-spv-sol": "^3.0.0",
-            "@summa-tx/relay-sol": "^2.0.1",
+            "@keep-network/keep-ecdsa": "file:https:/registry.npmjs.org/@keep-network/keep-ecdsa/-/keep-ecdsa-0.15.0-pre.5.tgz",
+            "@summa-tx/bitcoin-spv-sol": "^3.1.0",
+            "@summa-tx/relay-sol": "^2.0.2",
             "openzeppelin-solidity": "2.3.0"
           },
           "dependencies": {
@@ -5191,8 +5191,7 @@
               }
             },
             "@keep-network/keep-ecdsa": {
-              "version": "0.15.0-pre.5",
-              "resolved": "https://registry.npmjs.org/@keep-network/keep-ecdsa/-/keep-ecdsa-0.15.0-pre.5.tgz",
+              "version": "file:https:/registry.npmjs.org/@keep-network/keep-ecdsa/-/keep-ecdsa-0.15.0-pre.5.tgz",
               "integrity": "sha512-8lOKXiDdP5aSDcAnRAsnAAw4xrKipW3BfARdvo+/FnPLPWF4f1B+Fzib988LIDqSR9iaP2yZ78f3cJCH6OpwFQ==",
               "requires": {
                 "@keep-network/keep-core": ">1.1.0-rc <1.1.0",
@@ -5347,7 +5346,7 @@
               "integrity": "sha512-90hiq6/VqtQgX8Sp0EzeIsv3r+ellbGj4URKj5j30tLlZvRUpnAe9YbYnjl3pJM93GyXU0tghHhvXHq+5rnCKA=="
             },
             "@web3-js/scrypt-shim": {
-              "version": "0.1.0",
+              "version": "github:web3-js/scrypt-shim",
               "from": "github:web3-js/scrypt-shim",
               "requires": {
                 "scryptsy": "^2.1.0",
@@ -9042,7 +9041,7 @@
               },
               "dependencies": {
                 "bignumber.js": {
-                  "version": "2.0.7",
+                  "version": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
                   "from": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
                 },
                 "utf8": {
@@ -9526,7 +9525,7 @@
               },
               "dependencies": {
                 "bignumber.js": {
-                  "version": "2.0.7",
+                  "version": "git+https://github.com/debris/bignumber.js.git#master",
                   "from": "git+https://github.com/debris/bignumber.js.git#master"
                 },
                 "ethereum-common": {
@@ -9659,7 +9658,7 @@
               }
             },
             "websocket": {
-              "version": "1.0.29",
+              "version": "github:web3-js/WebSocket-Node#polyfill/globalThis",
               "from": "github:web3-js/WebSocket-Node#polyfill/globalThis",
               "requires": {
                 "debug": "^2.2.0",
@@ -11579,12 +11578,122 @@
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
       "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
     },
+    "bcfg": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/bcfg/-/bcfg-0.1.6.tgz",
+      "integrity": "sha512-BR2vwQZwu24aRm588XHOnPVjjQtbK8sF0RopRFgMuke63/REJMWnePTa2YHKDBefuBYiVdgkowuB1/e4K7Ue3g==",
+      "requires": {
+        "bsert": "~0.0.10"
+      }
+    },
+    "bcoin": {
+      "version": "git+https://github.com/bcoin-org/bcoin.git#8851582be817da7d6b6a1cfa6791b4baf3b8058f",
+      "from": "git+https://github.com/bcoin-org/bcoin.git#8851582",
+      "requires": {
+        "bcfg": "~0.1.6",
+        "bcrypto": "~3.1.11",
+        "bcurl": "^0.1.6",
+        "bdb": "~1.1.7",
+        "bdns": "~0.1.5",
+        "bevent": "~0.1.5",
+        "bfile": "~0.2.1",
+        "bfilter": "~1.0.5",
+        "bheep": "~0.1.5",
+        "binet": "~0.3.5",
+        "blgr": "~0.1.7",
+        "blru": "~0.1.6",
+        "blst": "~0.1.5",
+        "bmutex": "~0.1.6",
+        "bsert": "~0.0.10",
+        "bsip": "~0.1.9",
+        "bsock": "~0.1.9",
+        "bsocks": "~0.2.5",
+        "bstring": "~0.3.9",
+        "btcp": "~0.1.5",
+        "buffer-map": "~0.0.7",
+        "bufio": "~1.0.6",
+        "bupnp": "~0.2.6",
+        "bval": "~0.1.6",
+        "bweb": "~0.1.9",
+        "mrmr": "~0.1.8",
+        "n64": "~0.2.10"
+      }
+    },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "requires": {
         "tweetnacl": "^0.14.3"
+      }
+    },
+    "bcrypto": {
+      "version": "3.1.11",
+      "resolved": "https://registry.npmjs.org/bcrypto/-/bcrypto-3.1.11.tgz",
+      "integrity": "sha512-XHsle+v0aYjCyHZSwd3Insnu8GUe4cuf3+f07Z/mO+GLq60YqUyEIvpaSv4LAAJ4uf8UNYMSSQ0LslsV0r4tug==",
+      "requires": {
+        "bsert": "~0.0.10",
+        "bufio": "~1.0.6",
+        "loady": "~0.0.1",
+        "nan": "^2.13.2"
+      }
+    },
+    "bcurl": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/bcurl/-/bcurl-0.1.6.tgz",
+      "integrity": "sha512-noeDhfqFiUcNOUuZKErkXcbZfxBjn6duTfYPEfA4hAYXGr7gwVxkAWvIerxl3ZLLyn8jzh7Oi0nHlrLm1ST9Fw==",
+      "requires": {
+        "brq": "~0.1.7",
+        "bsert": "~0.0.10",
+        "bsock": "~0.1.8"
+      }
+    },
+    "bdb": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/bdb/-/bdb-1.1.7.tgz",
+      "integrity": "sha512-jtBnWEyDDK08dBbKL9LJeO2huZyBmbjBQMMVjU9RI1liJo6YDbv86uDHoaD4gniefd9pfxqOM1w6rYuwLVCXlQ==",
+      "requires": {
+        "bsert": "~0.0.10",
+        "loady": "~0.0.1"
+      }
+    },
+    "bdns": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/bdns/-/bdns-0.1.5.tgz",
+      "integrity": "sha512-LNVkfM7ynlAD0CvPvO9cKxW8YXt1KOCRQZlRsGZWeMyymUWVdHQpZudAzH9chaFAz6HiwAnQxwDemCKDPy6Mag==",
+      "requires": {
+        "bsert": "~0.0.10"
+      }
+    },
+    "bevent": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/bevent/-/bevent-0.1.5.tgz",
+      "integrity": "sha512-hs6T3BjndibrAmPSoKTHmKa3tz/c6Qgjv9iZw+tAoxuP6izfTCkzfltBQrW7SuK5xnY22gv9jCEf51+mRH+Qvg==",
+      "requires": {
+        "bsert": "~0.0.10"
+      }
+    },
+    "bfile": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/bfile/-/bfile-0.2.2.tgz",
+      "integrity": "sha512-X205SsJ7zFAnjeJ/pBLqDqF10x/4Su3pBy8UdVKw4hdGJk7t5pLoRi+uG4rPaDAClGbrEfT/06PGUbYiMYKzTg=="
+    },
+    "bfilter": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/bfilter/-/bfilter-1.0.5.tgz",
+      "integrity": "sha512-GupIidtCvLbKhXnA1sxvrwa+gh95qbjafy7P1U1x/2DHxNabXq4nGW0x3rmgzlJMYlVl+c8fMxoMRIwpKYlgcQ==",
+      "requires": {
+        "bsert": "~0.0.10",
+        "bufio": "~1.0.6",
+        "mrmr": "~0.1.6"
+      }
+    },
+    "bheep": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/bheep/-/bheep-0.1.5.tgz",
+      "integrity": "sha512-0KR5Zi8hgJBKL35+aYzndCTtgSGakOMxrYw2uszd5UmXTIfx3+drPGoETlVbQ6arTdAzSoQYA1j35vbaWpQXBg==",
+      "requires": {
+        "bsert": "~0.0.10"
       }
     },
     "bignumber.js": {
@@ -11598,6 +11707,15 @@
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
       "requires": {
         "file-uri-to-path": "1.0.0"
+      }
+    },
+    "binet": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/binet/-/binet-0.3.6.tgz",
+      "integrity": "sha512-6pm+Gc3uNiiJZEv0k8JDWqQlo9ki/o9UNAkLmr0EGm7hI5MboOJVIOlO1nw3YuDkLHWN78OPsaC4JhRkn2jMLw==",
+      "requires": {
+        "bs32": "~0.1.5",
+        "bsert": "~0.0.10"
       }
     },
     "bip39": {
@@ -11631,10 +11749,42 @@
         "readable-stream": "^3.4.0"
       }
     },
+    "blgr": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/blgr/-/blgr-0.1.8.tgz",
+      "integrity": "sha512-9AvDK+lc92q//63S8cHtkaB060YOZqoqd0DkMwn35mR1SrcY0FXnCHePHZFx6Oe1d/6wj8Lw7mKEGoShCUf3Yw==",
+      "requires": {
+        "bsert": "~0.0.10"
+      }
+    },
+    "blru": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/blru/-/blru-0.1.6.tgz",
+      "integrity": "sha512-34+xZ2u4ys/aUzWCU9m6Eee4nVuN1ywdxbi8b3Z2WULU6qvnfeHvCWEdGzlVfRbbhimG2xxJX6R77GD2cuVO6w==",
+      "requires": {
+        "bsert": "~0.0.10"
+      }
+    },
+    "blst": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/blst/-/blst-0.1.5.tgz",
+      "integrity": "sha512-TPl04Cx3CHdPFAJ2x9Xx1Z1FOfpAzmNPfHkfo+pGAaNH4uLhS58ExvamVkZh3jadF+B7V5sMtqvrqdf9mHINYA==",
+      "requires": {
+        "bsert": "~0.0.10"
+      }
+    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+    },
+    "bmutex": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/bmutex/-/bmutex-0.1.6.tgz",
+      "integrity": "sha512-nXWOXtQHbfPaMl6jyEF/rmRMrcemj2qn+OCAI/uZYurjfx7Dg3baoXdPzHOL0U8Cfvn8CWxKcnM/rgxL7DR4zw==",
+      "requires": {
+        "bsert": "~0.0.10"
+      }
     },
     "bn.js": {
       "version": "4.11.9",
@@ -11752,10 +11902,93 @@
         "electron-to-chromium": "^1.3.47"
       }
     },
+    "brq": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/brq/-/brq-0.1.8.tgz",
+      "integrity": "sha512-6SDY1lJMKXgt5TZ6voJQMH2zV1XPWWtm203PSkx3DSg9AYNYuRfOPFSBDkNemabzgpzFW9/neR4YhTvyJml8rQ==",
+      "requires": {
+        "bsert": "~0.0.10"
+      }
+    },
+    "bs32": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/bs32/-/bs32-0.1.6.tgz",
+      "integrity": "sha512-usjDesQqZ8ihHXOnOEQuAdymBHnJEfSd+aELFSg1jN/V3iAf12HrylHlRJwIt6DTMmXpBDQ+YBg3Q3DIYdhRgQ==",
+      "requires": {
+        "bsert": "~0.0.10"
+      }
+    },
     "bs58": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/bs58/-/bs58-2.0.1.tgz",
       "integrity": "sha1-VZCNWPGYKrogCPob7Y+RmYopv40="
+    },
+    "bs58check": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
+      "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+      "requires": {
+        "bs58": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "safe-buffer": "^5.1.2"
+      },
+      "dependencies": {
+        "bs58": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+          "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
+          "requires": {
+            "base-x": "^3.0.2"
+          }
+        }
+      }
+    },
+    "bsert": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.10.tgz",
+      "integrity": "sha512-NHNwlac+WPy4t2LoNh8pXk8uaIGH3NSaIUbTTRXGpE2WEbq0te/tDykYHkFK57YKLPjv/aGHmbqvnGeVWDz57Q=="
+    },
+    "bsip": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/bsip/-/bsip-0.1.9.tgz",
+      "integrity": "sha512-i7cVEfCthASPB3BYKS/pZN/D4kh4vToIlSAFcVBLNjzYl1UirT3E2PIGSfNnYR2qZ3UW1qnDavrWEHhLeSKt2A==",
+      "requires": {
+        "bsert": "~0.0.10",
+        "loady": "~0.0.1",
+        "nan": "^2.13.1"
+      }
+    },
+    "bsock": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/bsock/-/bsock-0.1.9.tgz",
+      "integrity": "sha512-/l9Kg/c5o+n/0AqreMxh2jpzDMl1ikl4gUxT7RFNe3A3YRIyZkiREhwcjmqxiymJSRI/Qhew357xGn1SLw/xEw==",
+      "requires": {
+        "bsert": "~0.0.10"
+      }
+    },
+    "bsocks": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/bsocks/-/bsocks-0.2.5.tgz",
+      "integrity": "sha512-w1yG8JmfKPIaTDLuR9TIxJM2Ma6nAiInRpLNZ43g3qPnPHjawCC4SV6Bdy84bEJQX1zJWYTgdod/BnQlDhq4Gg==",
+      "requires": {
+        "binet": "~0.3.5",
+        "bsert": "~0.0.10"
+      }
+    },
+    "bstring": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/bstring/-/bstring-0.3.9.tgz",
+      "integrity": "sha512-D95flI7SXL+UsQi9mW+hH+AK2AFfafIJi+3GbbyTAWMe2FqwR9keBxsjGiGd/JM+77Y9WsC+M4EhZVNVcym9jw==",
+      "requires": {
+        "bsert": "~0.0.10",
+        "loady": "~0.0.1",
+        "nan": "^2.13.1"
+      }
+    },
+    "btcp": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/btcp/-/btcp-0.1.5.tgz",
+      "integrity": "sha512-tkrtMDxeJorn5p0KxaLXELneT8AbfZMpOFeoKYZ5qCCMMSluNuwut7pGccLC5YOJqmuk0DR774vNVQLC9sNq/A=="
     },
     "btoa": {
       "version": "1.2.1",
@@ -11776,6 +12009,11 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
+    "buffer-map": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/buffer-map/-/buffer-map-0.0.7.tgz",
+      "integrity": "sha512-95try3p/vMRkIAAnJDaGkFhGpT/65NoeW6XelEPjAomWYR58RQtW4khn0SwKj34kZoE7uxL7w2koZSwbnszvQQ=="
+    },
     "buffer-to-arraybuffer": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/buffer-to-arraybuffer/-/buffer-to-arraybuffer-0.0.5.tgz",
@@ -11785,6 +12023,38 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
+    },
+    "bufio": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/bufio/-/bufio-1.0.7.tgz",
+      "integrity": "sha512-bd1dDQhiC+bEbEfg56IdBv7faWa6OipMs/AFFFvtFnB3wAYjlwQpQRZ0pm6ZkgtfL0pILRXhKxOiQj6UzoMR7A=="
+    },
+    "bupnp": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bupnp/-/bupnp-0.2.6.tgz",
+      "integrity": "sha512-J6ykzJhZMxXKN78K+1NzFi3v/51X2Mvzp2hW42BWwmxIVfau6PaN99gyABZ8x05e8MObWbsAis23gShhj9qpbw==",
+      "requires": {
+        "binet": "~0.3.5",
+        "brq": "~0.1.7",
+        "bsert": "~0.0.10"
+      }
+    },
+    "bval": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/bval/-/bval-0.1.6.tgz",
+      "integrity": "sha512-jxNH9gSx7g749hQtS+nTxXYz/bLxwr4We1RHFkCYalNYcj12RfbW6qYWsKu0RYiKAdFcbNoZRHmWrIuXIyhiQQ==",
+      "requires": {
+        "bsert": "~0.0.10"
+      }
+    },
+    "bweb": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/bweb/-/bweb-0.1.10.tgz",
+      "integrity": "sha512-3Kkz/rfsyAWUS+8DV5XYhwcgVN4DfDewrP+iFTcpQfdZzcF6+OypAq7dHOtXV0sW7U/3msA/sEEqz0MHZ9ERWg==",
+      "requires": {
+        "bsert": "~0.0.10",
+        "bsock": "~0.1.8"
+      }
     },
     "bytes": {
       "version": "3.1.0",
@@ -11938,6 +12208,11 @@
       "requires": {
         "delayed-stream": "~1.0.0"
       }
+    },
+    "commander": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.0.0.tgz",
+      "integrity": "sha512-s7EA+hDtTYNhuXkTlhqew4txMZVdszBmKWSPEMxGr8ru8JXR7bLUFIAtPhcSuFdJQ0ILMxnJi8GkQL0yvDy/YA=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -27892,6 +28167,11 @@
         }
       }
     },
+    "loady": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/loady/-/loady-0.0.5.tgz",
+      "integrity": "sha512-uxKD2HIj042/HBx77NBcmEPsD+hxCgAtjEWlYNScuUjIsh/62Uyu39GOR68TBR68v+jqDL9zfftCWoUo4y03sQ=="
+    },
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
@@ -28151,6 +28431,15 @@
       "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.12.0.tgz",
       "integrity": "sha512-/P/HtrlvBxY4o/PzXY9cCNBrdylDNxg7gnrv2sMNxj+UJ2m8jSpl0/A6fuJeNAWr99ZvGWH8XCbE0vmnM5KupQ=="
     },
+    "mrmr": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/mrmr/-/mrmr-0.1.9.tgz",
+      "integrity": "sha512-t3nbygZEPN0vkoW+985GAVw/OOQODmAwPwCfaQUCQbTaZG40s7wmFaC8AKu4oL0g7hF4xcstwkvzW6bu4QxRSg==",
+      "requires": {
+        "bsert": "~0.0.10",
+        "loady": "~0.0.1"
+      }
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -28193,6 +28482,11 @@
           }
         }
       }
+    },
+    "n64": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/n64/-/n64-0.2.10.tgz",
+      "integrity": "sha512-uH9geV4+roR1tohsrrqSOLCJ9Mh1iFcDI+9vUuydDlDxUS1UCAWUfuGb06p3dj3flzywquJNrGsQ7lHP8+4RVQ=="
     },
     "nan": {
       "version": "2.14.1",
@@ -29948,6 +30242,14 @@
       "optional": true,
       "requires": {
         "string-width": "^1.0.2 || 2"
+      }
+    },
+    "wif": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/wif/-/wif-2.0.6.tgz",
+      "integrity": "sha1-CNP1IFbGZnkplyb63g1DKudLRwQ=",
+      "requires": {
+        "bs58check": "<3.0.0"
       }
     },
     "wrappy": {


### PR DESCRIPTION
Here we update the e2e test module to align with the latest changes in the system submodules. Specifically:

- Updated `package-lock.json` to reflect changes in the dependencies and make `npm install` pass
- Switched `deposit.getSatoshiLotSize` usage to the new name of this method