### PR TITLE
E2E cron job parameters change

### DIFF
--- a/deployments/e2e-test/e2e-test-configmap.yml
+++ b/deployments/e2e-test/e2e-test-configmap.yml
@@ -7,5 +7,5 @@ data:
   bitcoin-electrum-host: "34.70.251.19"
   bitcoin-electrum-port: "8080"
   bitcoin-network: "testnet"
-  ethereum-node: "wss://ropsten.infura.io/ws/v3/880f2a054e784898a55627bd5f047917"
+  ethereum-node: "wss://ropsten.infura.io/ws/v3/dfb807704e67496995fa8e824edcc1b5"
   lot-size-satoshis: "1000000"

--- a/deployments/e2e-test/e2e-test-configmap.yml
+++ b/deployments/e2e-test/e2e-test-configmap.yml
@@ -8,3 +8,4 @@ data:
   bitcoin-electrum-port: "8080"
   bitcoin-network: "testnet"
   ethereum-node: "wss://ropsten.infura.io/ws/v3/880f2a054e784898a55627bd5f047917"
+  lot-size-satoshis: "1000000"

--- a/deployments/e2e-test/e2e-test-cronjob.yaml
+++ b/deployments/e2e-test/e2e-test-cronjob.yaml
@@ -16,7 +16,7 @@ spec:
         type: e2e-test
     spec:
       backoffLimit: 0
-      activeDeadlineSeconds: 3600
+      activeDeadlineSeconds: 7200
       template:
         spec:
           containers:
@@ -28,7 +28,8 @@ spec:
               "--bitcoin-network", "$(BITCOIN_NETWORK)",
               "--bitcoin-depositor-pk", "$(BITCOIN_DEPOSITOR_PK)",
               "--ethereum-node", "$(ETHEREUM_NODE)",
-              "--ethereum-pk", "$(ETHEREUM_PK)"
+              "--ethereum-pk", "$(ETHEREUM_PK)",
+              "--lot-size-satoshis", "$(LOT_SIZE_SATOSHIS)"
             ]
             env:
               - name: BITCOIN_ELECTRUM_HOST
@@ -61,4 +62,9 @@ spec:
                   secretKeyRef:
                     name: e2e-test-secret
                     key: ethereum-pk
+              - name: LOT_SIZE_SATOSHIS
+                valueFrom:
+                  configMapKeyRef:
+                    name: e2e-test-config
+                    key: lot-size-satoshis
           restartPolicy: Never

--- a/deployments/e2e-test/e2e-test-cronjob.yaml
+++ b/deployments/e2e-test/e2e-test-cronjob.yaml
@@ -7,7 +7,7 @@ metadata:
     app: tbtc
     type: e2e-test
 spec:
-  schedule: '0 */4 * * *'
+  schedule: '0 */8 * * *'
   concurrencyPolicy: Forbid
   jobTemplate:
     metadata:

--- a/e2e/e2e-test.js
+++ b/e2e/e2e-test.js
@@ -30,14 +30,15 @@ program
     .option('--bitcoin-depositor-pk <privateKey>', "private key of the Bitcoin depositor in WIF format", "cTj6Z9fxMr4pzfpUhiN8KssVzZjgQz9zFCfh87UrH8ZLjh3hGZKF")
     .option('--ethereum-node <url>', "ethereum node url", "ws://127.0.0.1:8546")
     .option('--ethereum-pk <privateKey>', "private key of ethereum account", "f95e1da038f1fd240cb0c966d8826fb5c0369407f76f34736a5c381da7ca0ecd")
+    .option('--lot-size-satoshis <lot>', "lot size in satoshis", (lot) => parseInt(lot, 10), 100000)
     .parse(process.argv)
 
 console.log("\nScript options values: ", program.opts(), "\n")
 
 const depositsCount = 2
-const satoshiLotSize = 100000 // 0.001 BTC
 const signerFeeDivisor = 0.0005 // 0.05%
-const tbtcDepositAmount = 1000000000000000 // satoshiLotSize * satoshiMultiplier
+const satoshiMultiplier = 10000000000 // 10^10
+const tbtcDepositAmount = program.lotSizeSatoshis * satoshiMultiplier
 const signerFee = signerFeeDivisor * tbtcDepositAmount
 const tbtcDepositAmountMinusSignerFee = tbtcDepositAmount - signerFee
 const satoshiRedemptionFee = 150
@@ -103,7 +104,7 @@ async function run() {
     const deposits = []
     for (let i = 1; i <= depositsCount; i++) {
         console.log(`\nStarting deposit number [${i}]...\n`)
-        const deposit = await createDeposit(tbtc, satoshiLotSize, bitcoinDepositorKeyRing)
+        const deposit = await createDeposit(tbtc, program.lotSizeSatoshis, bitcoinDepositorKeyRing)
         deposits.push(deposit)
 
         assertMintedTbtcAmount(web3, deposit, tbtcDepositAmountMinusSignerFee)
@@ -160,7 +161,7 @@ async function run() {
     )
 
     const afterRedemptionBtcBalance = beforeRedemptionBtcBalance.add(
-        web3.utils.toBN(satoshiLotSize).sub(web3.utils.toBN(satoshiRedemptionFee))
+        web3.utils.toBN(program.lotSizeSatoshis).sub(web3.utils.toBN(satoshiRedemptionFee))
     )
 
     console.log(


### PR DESCRIPTION
Here we change several things around e2e cron job parameters:

- We enable passing the lot size as a script input instead of relying on a constant value.
- We set the cron to run every `8` hours instead of `4`
- We change the infura account used by the cron
- We set the lot size used by cron job to `1000000`
- We increased the `activeDeadlineSeconds` to `2` hours. 