### PR TITLE
Chaning infura endpoint, cron schedule and blocks timespan

### DIFF
--- a/.github/workflows/e2e-summary.yaml
+++ b/.github/workflows/e2e-summary.yaml
@@ -2,8 +2,8 @@ name: e2e summary
 
 on:
   schedule:
-    # every 10th minute
-    - cron: '*/10 * * * *'
+    # every 4th hour
+    - cron: '0 */4 * * *'
 
 jobs:
     build:
@@ -41,9 +41,9 @@ jobs:
             --bitcoin-electrum-host 34.70.251.19 \
             --bitcoin-electrum-port 8080 \
             --bitcoin-network testnet \
-            --ethereum-node wss://ropsten.infura.io/ws/v3/a6e0ba36c6b44333bd56c5c8cc681cc3 \
+            --ethereum-node wss://ropsten.infura.io/ws/v3/c7d9a83a904d440ba19a7acda98f4c72 \
             --ethereum-pk 033cea2b77cbd50c02cbc57573cf4389b8c785642c2107c7e1614df9876b787b \
-            --blocks-timespan 1000
+            --blocks-timespan 500
 
         - name: Deploy e2e summary site
           run: |


### PR DESCRIPTION
This PR is related to e2e summary task where we fetch all created tbtc deposits on Ropsten and create a summary table. This change is to replace Infura endpoint (because of the limits) and frequency of running `e2e-summary.js` script