### PR TITLE
Tweak E2E cronjob parameters

### DIFF
--- a/deployments/e2e-test/e2e-test-cronjob.yaml
+++ b/deployments/e2e-test/e2e-test-cronjob.yaml
@@ -7,8 +7,8 @@ metadata:
     app: tbtc
     type: e2e-test
 spec:
-  schedule: '0 */8 * * *'
-  concurrencyPolicy: Forbid
+  schedule: '0 */1 * * *'
+  concurrencyPolicy: Replace
   jobTemplate:
     metadata:
       labels:
@@ -16,7 +16,6 @@ spec:
         type: e2e-test
     spec:
       backoffLimit: 0
-      activeDeadlineSeconds: 7200
       template:
         spec:
           containers:

--- a/deployments/e2e-test/e2e-test-cronjob.yaml
+++ b/deployments/e2e-test/e2e-test-cronjob.yaml
@@ -7,7 +7,7 @@ metadata:
     app: tbtc
     type: e2e-test
 spec:
-  schedule: '0 */1 * * *'
+  schedule: '0 */4 * * *'
   concurrencyPolicy: Replace
   jobTemplate:
     metadata:


### PR DESCRIPTION
Improved timed out jobs replacement and changed the cron schedule to run every 4 hours.

Refs https://github.com/keep-network/tbtc/issues/703