### PR TITLE
e2e report config

### DIFF
--- a/.github/workflows/e2e-summary.yaml
+++ b/.github/workflows/e2e-summary.yaml
@@ -2,8 +2,8 @@ name: e2e summary
 
 on:
   schedule:
-    # every 4th hour
-    - cron: '0 */4 * * *'
+    # every 12th hour
+    - cron: '0 */12 * * *'
 
 jobs:
     build:

--- a/.github/workflows/e2e-summary.yaml
+++ b/.github/workflows/e2e-summary.yaml
@@ -43,7 +43,7 @@ jobs:
             --bitcoin-network testnet \
             --ethereum-node wss://ropsten.infura.io/ws/v3/${{secrets.INFURA_PROJECT_ID}} \
             --ethereum-pk ${{secrets.ETH_PRIVATE_KEY}} \
-            --blocks-timespan 500
+            --blocks-timespan 7500
 
         - name: Deploy e2e summary site
           run: |


### PR DESCRIPTION
- Increasing blocks to 7500 (~24hour) which will result in search frame from: `currentBlock - 7500` to `currentBlock`
- Schedule job to run every 12th hour
- Iterating only through "ours" deposits that were run from `e2e-test.js`