### PR TITLE
Updated tbtc.js version for end-to-end test Dockerfile

### DIFF
--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:14.3.0-alpine3.11
 
-ENV TBTCJS_VERSION 0.18.0-rc.1
+ENV TBTCJS_VERSION 0.18.0-rc.2
 
 RUN apk add --no-cache \
     jq \


### PR DESCRIPTION
The most recent version of tbtc.js is `0.18.0-rc.2`. Updated end-to-end `Dockerfile` to point to that release.