### PR TITLE
Add signatures count to the beacon inspection script

### DIFF
--- a/inspector/package-lock.json
+++ b/inspector/package-lock.json
@@ -2181,6 +2181,15 @@
         }
       }
     },
+    "abi-decoder": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/abi-decoder/-/abi-decoder-2.3.0.tgz",
+      "integrity": "sha512-RZXG5mo1JhJjTBg/4NXlS8hyTr2fxiuFaz3UveRpoX9IIc3LPHmWz89dFqTHNQVbWi3VZqxSJqfUwWpb/mCHxA==",
+      "requires": {
+        "web3-eth-abi": "^1.2.1",
+        "web3-utils": "^1.2.1"
+      }
+    },
     "abstract-leveldown": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",

--- a/inspector/package.json
+++ b/inspector/package.json
@@ -9,10 +9,11 @@
     "@keep-network/keep-core": "1.3.0",
     "@keep-network/keep-ecdsa": "1.2.1",
     "@keep-network/tbtc": "1.1.0",
+    "@truffle/contract": "^4.1.13",
+    "@truffle/hdwallet-provider": "^1.0.25",
+    "abi-decoder": "^2.3.0",
     "cli-color": "^2.0.0",
     "truffle": "^5.1.25",
-    "@truffle/hdwallet-provider": "^1.0.25",
-    "@truffle/contract": "^4.1.13",
     "web3": "^1.2.7"
   },
   "devDependencies": {}


### PR DESCRIPTION
Added supporting signatures field to the group summary prepared by the beacon inspection script. That information gives more context for DKG outcomes and can be useful while debugging DKG problems.