### PR TITLE
e2e nightly test fixes for CircleCI

### DIFF
--- a/e2e/e2e-test.js
+++ b/e2e/e2e-test.js
@@ -30,7 +30,7 @@ program
     .option('--bitcoin-depositor-pk <privateKey>', "private key of the Bitcoin depositor in WIF format", "cTj6Z9fxMr4pzfpUhiN8KssVzZjgQz9zFCfh87UrH8ZLjh3hGZKF")
     .option('--ethereum-node <url>', "ethereum node url", "ws://127.0.0.1:8546")
     .option('--ethereum-pk <privateKey>', "private key of ethereum account", "f95e1da038f1fd240cb0c966d8826fb5c0369407f76f34736a5c381da7ca0ecd")
-    .option('--lot-size-satoshis <lot>', "lot size in satoshis", (lot) => parseInt(lot, 10), 100000)
+    .option('--lot-size-satoshis <lot>', "lot size in satoshis", (lot) => parseInt(lot, 10), 1000000)
     .parse(process.argv)
 
 console.log("\nScript options values: ", program.opts(), "\n")
@@ -41,7 +41,7 @@ const satoshiMultiplier = 10000000000 // 10^10
 const tbtcDepositAmount = program.lotSizeSatoshis * satoshiMultiplier
 const signerFee = signerFeeDivisor * tbtcDepositAmount
 const tbtcDepositAmountMinusSignerFee = tbtcDepositAmount - signerFee
-const satoshiRedemptionFee = 150
+const satoshiRedemptionFee = 2700
 
 bcoin.set(program.bitcoinNetwork)
 

--- a/install-tbtc.sh
+++ b/install-tbtc.sh
@@ -55,6 +55,9 @@ printf "${LOG_START}Running install script...${LOG_END}"
 
 cd "$WORKDIR/tbtc"
 
+# Remove node modules for clean installation
+rm -rf /solidity/node_modules
+
 # Run tBTC install script.  Answer with ENTER on emerging prompt.
 printf '\n' | ./scripts/install.sh
 

--- a/install.sh
+++ b/install.sh
@@ -14,14 +14,14 @@ set -e
 # Install tBTC.
 ./install-tbtc.sh
 
-# Do not install keep network dApps for e2e nightly test
+# Install tBTC dApp.
+./install-tbtc-dapp.sh
+
+# Do not install keep dashboard dApp for e2e nightly test
 if [[ $E2E_TEST != true ]]
 then
     # Install Keep Dashboard.
     ./install-keep-dashboard.sh
-
-    # Install tBTC dApp.
-    ./install-tbtc-dapp.sh
 fi
 
 echo "Installation script executed successfully with versions of submodules:\n$(git submodule)"


### PR DESCRIPTION
Adding changes that should fix our e2e nightly test for deposits & redemption.

Successful build was tested on a parallel testing branch [here](https://app.circleci.com/pipelines/github/keep-network/local-setup/414/workflows/d9320b8f-dee6-4898-8875-f36018f0c72a/jobs/178) 