### PR TITLE
Update auto-setup doc

### DIFF
--- a/docs/auto-setup.adoc
+++ b/docs/auto-setup.adoc
@@ -18,6 +18,13 @@ First, go to the `deployments/local-setup-environment` directory and build the e
 ```
 packer build -only=vagrant packerfile.json
 ```
+
+[TIP]
+If you see an error "vagrant: error: SSH Port was not properly retrieved from
+SSHConfig." or "vagrant: strconv.Atoi: parsing "": invalid syntax" try to turn
+off your antivirus completely. You can also try to disable the SSL scanning in
+your antivirus options.
+
 An output directory named `vagrant-box` containing `package.box` file should be created.
 
 Then, switch the directory to `deployments/local-setup-instance` and import


### PR DESCRIPTION
This PR adds a tip to the auto-setup doc that informs to turn off an antivirus in case of an error while executing packer build command.

![image](https://user-images.githubusercontent.com/40306834/104335273-84661200-54f3-11eb-805f-cf06873fe518.png)
