### PR TITLE
Adding troubleshooting section and another solution for vagrant error

### DIFF
--- a/docs/auto-setup.adoc
+++ b/docs/auto-setup.adoc
@@ -20,10 +20,8 @@ packer build -only=vagrant packerfile.json
 ```
 
 [TIP]
-If you see an error "vagrant: error: SSH Port was not properly retrieved from
-SSHConfig." or "vagrant: strconv.Atoi: parsing "": invalid syntax" try to turn
-off your antivirus completely. You can also try to disable the SSL scanning in
-your antivirus options.
+If you see an error `vagrant: error: SSH Port was not properly retrieved from
+SSHConfig.` or `vagrant: strconv.Atoi: parsing "": invalid syntax` refer to <<ssh-port,Troubleshooting>>.
 
 An output directory named `vagrant-box` containing `package.box` file should be created.
 
@@ -135,3 +133,16 @@ or, destroy the machine:
 vagrant destroy
 ```
 and run it again.
+
+
+== Troubleshooting
+
+[#ssh-port]
+=== SSH Port was not properly retrieved from SSHConfig
+
+If you see an error `vagrant: error: SSH Port was not properly retrieved from
+SSHConfig.` or `vagrant: strconv.Atoi: parsing "": invalid syntax` try to:
+
+- Turn off your antivirus completely. You can also try to disable the SSL scanning in your antivirus options.
+
+- If that doesn't help (as may happen after update to MacOS Big Sur), execute `csrutil enable && reboot` in the Recovery Mode (as described in this https://apple.stackexchange.com/a/410145[Stack Exchange answer])

--- a/docs/auto-setup.adoc
+++ b/docs/auto-setup.adoc
@@ -145,4 +145,6 @@ SSHConfig.` or `vagrant: strconv.Atoi: parsing "": invalid syntax` try to:
 
 - Turn off your antivirus completely. You can also try to disable the SSL scanning in your antivirus options.
 
-- If that doesn't help (as may happen after update to MacOS Big Sur), execute `csrutil enable && reboot` in the Recovery Mode (as described in this https://apple.stackexchange.com/a/410145[Stack Exchange answer])
+- If that doesn't help (as may happen after update to MacOS Big Sur), execute `csrutil enable && reboot` in the Recovery Mode (as described in this https://apple.stackexchange.com/a/410145[Stack Exchange answer]).
+
+- If all of the above fails you can also use `PACKER_LOG=1 packer build -only=vagrant packerfile.json` to debug the building process and see the exact issue.


### PR DESCRIPTION
After MacOS update to Big Sur version the vagrant setup didn't work
(SSH Port was not properly retrieved from SSHConfig). Problem can
be solved by execution of 'csrutil enable && reboot' command in the
Recovery Mode. Description of the solution added to the document.