### PR TITLE
Add .envrc to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ vagrant-box
 .vagrant
 *.log
 e2e/site/index.html
+.envrc


### PR DESCRIPTION
.envrc allows [direnv](https://direnv.net) to manage environment variables on a per-folder level, which is useful for managing environment variables across different repos (or different clones of the same repo).

For example, I can stick:

```
export GOPATH="/Users/beaushinkle/go"
```

in my `.envrc` (or whatever other environment variables specific to keep) in their relevant folders and it won't clutter my bash profile.