### PR TITLE
Prefix Manual Setup Doc Shell Commands With $

### DIFF
--- a/docs/manual-setup.adoc
+++ b/docs/manual-setup.adoc
@@ -26,20 +26,20 @@ To run the test script, please use Node `v14.3.0`.
 We recommend using https://github.com/nvm-sh/nvm[nvm] to manage node versions easily.
 You can install both versions by doing:
 ```
-nvm install 11.15.0
-nvm install 14.3.0
+$ nvm install 11.15.0
+$ nvm install 14.3.0
 ```
 And use the specific version:
 ```
-nvm use 11.15.0
-nvm use 14.3.0
+$ nvm use 11.15.0
+$ nvm use 14.3.0
 ```
 
 == Installing the system
 . Initialize local `geth` using:
 +
 ```
-./initialize-geth.sh
+$ ./initialize-geth.sh
 ```
 +
 You can skip this step if your local geth is already initialized. This script clears all Ethereum client data, initilizes genesis block, and funds five accounts. All client data are kept in the working directory of this project so all the data used for other projects stay untouched.
@@ -47,17 +47,17 @@ You can skip this step if your local geth is already initialized. This script cl
 . Run local `geth` node using:
 +
 ```
-./run-geth.sh
+$ ./run-geth.sh
 ```
 . Run local Bitcoin Core node and ElectrumX using:
 +
 ```
-./run-bitcoin.sh
+$ ./run-bitcoin.sh
 ```
 . Run Keep & tBTC installation script:
 +
 ```
-./install.sh
+$ ./install.sh
 ```
 +
 This script will fetch `keep-core`, `keep-ecdsa`, and `tbtc` source code, deploy contracts of `keep-core`, `keep-ecdsa`, and `tbtc`. It will also build `keep-core` and `keep-ecdsa` off-chain clients.
@@ -76,20 +76,20 @@ The above installation script will configure:
 
 To run the `keep-core` client use:
 ```
-./run-core-1.sh
+$ ./run-core-1.sh
 ```
 
 It is enough to run one `keep-core` client to generate a group and produce relay entries. Setting up more than one client locally is possible but consumes more resources.
 
 To run `keep-ecdsa` clients use:
 ```
-./run-ecdsa-1.sh
+$ ./run-ecdsa-1.sh
 ```
 ```
-./run-ecdsa-2.sh
+$ ./run-ecdsa-2.sh
 ```
 ```
-./run-ecdsa-3.sh
+$ ./run-ecdsa-3.sh
 ```
 
 There are at least 3 `keep-ecdsa` clients needed to open a keep. Setting up more than three clients locally is possible but consumes more resources.
@@ -100,14 +100,14 @@ Before the beacon is able to produce a first relay entry, genesis needs to happe
 
 Genesis should be triggered after `keep-core` client started with:
 ```
-cd keep-core
-KEEP_ETHEREUM_PASSWORD="password" ./keep-core --config configs/config.local.1.toml relay genesis
+$ cd keep-core
+$ KEEP_ETHEREUM_PASSWORD="password" ./keep-core --config configs/config.local.1.toml relay genesis
 ```
 
 Bonded ECDSA keep factory from `keep-ecdsa` contracts requests for new relay entry to reseed after each signer selection but it is also possible to request for a new relay entry manually with:
 ```
-cd keep-core
-KEEP_ETHEREUM_PASSWORD="password" ./keep-core --config configs/config.local.1.toml relay request
+$ cd keep-core
+$ KEEP_ETHEREUM_PASSWORD="password" ./keep-core --config configs/config.local.1.toml relay request
 ```
 
 == How to interact with the system
@@ -124,14 +124,14 @@ end-to-end tests. Before you start interacting, make sure you:
 
 To run the Keep Dashboard dApp invoke:
 ```
-./run-keep-dashboard.sh
+$ ./run-keep-dashboard.sh
 ```
 
 === tBTC dApp
 
 To run the tBTC dApp against the local Bitcoin network invoke:
 ```
-./run-tbtc-dapp.sh
+$ ./run-tbtc-dapp.sh
 ```
 
 === Testing the Deposit/Redemption Flow
@@ -218,9 +218,9 @@ Confirm all of the transactions and verify that the TBTC has left your wallet. Y
 
 To run the automated end-to-end scenario switch to Node 14.3.0:
 ```
-nvm use 14.3.0
+$ nvm use 14.3.0
 ```
 Then invoke:
 ```
-./run-e2e-test.sh
+$ ./run-e2e-test.sh
 ```


### PR DESCRIPTION
Having the `$` is an indicator to the reader that those commands are
meant to be run in a bash-style shell, rather than some other repl or
anywhere else.

In #61, @Shadowfiend mentioned:

> At some point we should probably go ahead and make this change throughout the file, but for now let's roll with what we've got 🚢

No time like the present, so here it is :)