### PR TITLE
Update call from install-tbtc.sh to keep-ecdsa/scripts/initialize.sh

### DIFF
--- a/install-tbtc.sh
+++ b/install-tbtc.sh
@@ -88,8 +88,7 @@ printf "${LOG_START}TBTCSystem contract address is: ${TBTC_SYSTEM_CONTRACT_ADDRE
 
 cd "$WORKDIR/keep-ecdsa"
 
-# Run keep-ecdsa initialization script. Answer with ENTER on the first prompt
-# and with TBTCSystem contract address on the second one.
-printf '\n'${TBTC_SYSTEM_CONTRACT_ADDRESS}'\n' | ./scripts/initialize.sh
+# Run keep-ecdsa initialization script.
+./scripts/initialize.sh --network local --application-address $TBTC_SYSTEM_CONTRACT_ADDRESS
 
 printf "${DONE_START}keep-ecdsa initialized successfully!${DONE_END}"


### PR DESCRIPTION
Prior to 0d9369ee4e398ee768d504605ee0606f5a4b57b4 in keep-ecdsa the initialization script operated by passing in command-line prompts via `read`. The aforementioned commit got rid of those in favor of argument flags, so we use those here.

tagging @Shadowfiend or @dimpar for review