### PR TITLE
Expose the Bitcoin Block Data to the Host Machine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea
 /ethereum/data/geth/
+/bitcoin/bitcoind/data/
 /storage/
 node_modules
 vagrant-box

--- a/bitcoin/docker-compose.yml
+++ b/bitcoin/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     container_name: bitcoind
     ports:
       - 18332:18332
+    volumes:
+      - ./bitcoind/data:/workdir/datadir
     build: ./bitcoind
   electrumx:
     container_name: electrumx


### PR DESCRIPTION
This PR adds a new folder at `bitcoin/bitcoind/data` to the local project, and then configures that folder as a volume in the bitcoin docker. The result is that when we execute `./run-bitcoin.sh`, we now are able to natively view the block data:
```
beaushinkle@Beaus-MBP ~/l/b/bitcoind (expose-bitcoin-chain-data)> tree
.
├── Dockerfile
├── data
│   └── regtest
│       ├── banlist.dat
│       ├── bitcoind.pid
│       ├── blocks
│       │   ├── blk00000.dat
│       │   ├── index
│       │   │   ├── 000007.log
│       │   │   ├── CURRENT
│       │   │   ├── LOCK
│       │   │   └── MANIFEST-000006
│       │   └── rev00000.dat
│       ├── chainstate
│       │   ├── 000005.ldb
│       │   ├── 000008.log
│       │   ├── CURRENT
│       │   ├── LOCK
│       │   └── MANIFEST-000007
│       ├── debug.log
│       ├── indexes
│       │   └── txindex
│       │       ├── 000005.ldb
│       │       ├── 000008.ldb
│       │       ├── 000009.log
│       │       ├── CURRENT
│       │       ├── LOCK
│       │       └── MANIFEST-000007
│       ├── peers.dat
│       └── wallets
│           ├── database
│           │   ├── log.0000000005
│           │   └── log.0000000006
│           ├── db.log
│           └── wallet.dat
└── entrypoint.sh
```

This lets us run block explorers or APIs on top of that block data (like electrs).

Tagging @nkuba for review