### PR TITLE
Add sendRawTransaction and getBalance

### DIFF
--- a/bitcoind-wallet/bin/cli.js
+++ b/bitcoind-wallet/bin/cli.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node --experimental-modules --experimental-json-modules
 
 import { createRequire } from "module"
-import { sendToAddress, getNewAddress } from "./../index.js"
+import { sendToAddress, getNewAddress, sendRawTransaction, getBalance } from "./../index.js"
 
 const meow = createRequire(import.meta.url)("meow")
 
@@ -10,8 +10,10 @@ const cli = meow(`
     $ bitcoind-wallet <command> <arg...>
 
   Commands
-    sendToAddress     [address] [btc] Send btc to an address
-    getNewAddress     Get an address to receive btc
+    sendToAddress         [address] [btc] Send btc to an address
+    getNewAddress         Get an address to receive btc
+    sendRawTransaction    [transaction] Broadcast a raw transaction
+    getBalance            [address] Get the balance of an address
 `)
 
 const [cmd, ...args] = cli.input
@@ -20,6 +22,10 @@ if (cmd === 'sendToAddress') {
   sendToAddress(...args)
 } else if (cmd === 'getNewAddress') {
   getNewAddress()
+} else if (cmd === 'sendRawTransaction') {
+  sendRawTransaction(...args)
+} else if (cmd === 'getBalance') {
+  getBalance(...args)
 } else if (cmd) {
   console.error('Unknown command')
   process.exit(1)

--- a/bitcoind-wallet/index.js
+++ b/bitcoind-wallet/index.js
@@ -14,3 +14,14 @@ export async function getNewAddress() {
   console.log(address)
   return address
 }
+
+export async function sendRawTransaction(transaction) {
+	return bitcoinRpc.sendrawtransactionAsync(transaction)
+}
+
+export async function getBalance(address) {
+	await bitcoinRpc.importaddressAsync(address)
+	const balance = (await bitcoinRpc.getreceivedbyaddressAsync(address, 0)).result
+	console.log(balance)
+	return balance
+}


### PR DESCRIPTION
These additional methods provide convenience around verifying the liquidation recovery flow. To test:

```
beaushinkle@Beaus-MBP ~> bitcoind-wallet getNewAddress
bcrt1qdw2xz0jntd7xwmgcrat483amspj55rwuq52vva
beaushinkle@Beaus-MBP ~> bitcoind-wallet getBalance bcrt1qdw2xz0jntd7xwmgcrat483amspj55rwuq52vva
0
beaushinkle@Beaus-MBP ~> bitcoind-wallet sendToAddress bcrt1qp5cps4cryf9fq958v7rez5jqzctswfml2z4y5q 2.3
beaushinkle@Beaus-MBP ~> bitcoind-wallet getBalance bcrt1qp5cps4cryf9fq958v7rez5jqzctswfml2z4y5q
2.3
```

```
beaushinkle@Beaus-MBP ~/l/t/s/scripts (master) [SIGINT]> curl -d '01000000000101fa42b57a4f75570a53889128db1a13b71dd553fd876269ca59987c46af5285810000000000000000000309cc320000000000160014a0aedee089b0cfa34e1e29c2dd2e618b19e8b95309cc320000000000160014f8c4e8695f8c2e0f598f8f00c2c4a83b17b0c4fa09cc320000000000160014fada4235022b32a31f97adbc954e6a7bbb7b32ba02473044022016442860250764c171b0a28a35e3dc14591ba6c6032539691281350d9e8518f90220774bcdbda9b3729edb5b50d35e56fa13f58236a0597e5624620ad09b4b720936012102a0ef9e7f1677e58ae82326970647c8e0fa2624540a6ef9a340a2a4adee054edf00000000' -X POST localhost:3002/tx
sendrawtransaction RPC error: {"code":-25,"message":"bad-txns-inputs-missingorspent”}
beaushinkle@Beaus-MBP ~> bitcoind-wallet sendRawTransaction 01000000000101fa42b57a4f75570a53889128db1a13b71dd553fd876269ca59987c46af5285810000000000000000000309cc320000000000160014a0aedee089b0cfa34e1e29c2dd2e618b19e8b95309cc320000000000160014f8c4e8695f8c2e0f598f8f00c2c4a83b17b0c4fa09cc320000000000160014fada4235022b32a31f97adbc954e6a7bbb7b32ba02473044022016442860250764c171b0a28a35e3dc14591ba6c6032539691281350d9e8518f90220774bcdbda9b3729edb5b50d35e56fa13f58236a0597e5624620ad09b4b720936012102a0ef9e7f1677e58ae82326970647c8e0fa2624540a6ef9a340a2a4adee054edf00000000
(node:69393) ExperimentalWarning: Importing JSON modules is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
Error: Promise rejected with value: { code: -25, message: 'bad-txns-inputs-missingorspent' }
    at process.<anonymous> (/Users/beaushinkle/local/bitcoind-wallet/node_modules/hard-rejection/index.js:15:12)
    at process.emit (node:events:379:20)
    at emit (node:internal/process/promises:202:22)
    at processPromiseRejections (node:internal/process/promises:223:25)
    at processTicksAndRejections (node:internal/process/task_queues:95:32)
```
(shows that electrs and bitcoind-wallet are both returning the same result on the same transaction)

tagging @nkuba for review