### PR TITLE
Refactor installation to use npm links and updated module's install scripts

### DIFF
--- a/install-keep-core.sh
+++ b/install-keep-core.sh
@@ -34,7 +34,7 @@ printf "${LOG_START}Running install script...${LOG_END}"
 
 cd keep-core
 
-# Run keep-core install script. Answer with ENTER twice on emerging prompts.
-printf '\n\n' | ./scripts/install.sh
+# Run keep-core install script.
+./scripts/install.sh
 
 printf "${DONE_START}keep-core deployed successfully!${DONE_END}"

--- a/install-keep-ecdsa.sh
+++ b/install-keep-ecdsa.sh
@@ -47,9 +47,15 @@ cd keep-ecdsa/solidity
 TMP_FILE=$(mktemp /tmp/truffle.js.XXXXXXXXXX)
 sed -e 's/\port\:.*/\port\: '8546,'/g;s/\websockets\:.*/\websockets\: 'true,'/g' truffle.js > $TMP_FILE
 mv $TMP_FILE truffle.js
-cd ..
+
+printf "${LOG_START}Linking dependencies...${LOG_END}"
+
+cd "$WORKDIR/keep-core/solidity"
+npm link
 
 printf "${LOG_START}Running install script...${LOG_END}"
+
+cd "$WORKDIR/keep-ecdsa"
 
 ./scripts/install.sh
 

--- a/install-keep-ecdsa.sh
+++ b/install-keep-ecdsa.sh
@@ -51,13 +51,6 @@ cd ..
 
 printf "${LOG_START}Running install script...${LOG_END}"
 
-# Run keep-ecdsa install script.  Answer with ENTER twice on emerging prompts.
-printf '\n\n' | ./scripts/install.sh
-
-printf "${LOG_START}Updating keep-ecdsa node_modules...${LOG_END}"
-
-cd $WORKDIR
-rm -rf keep-ecdsa/solidity/node_modules/@keep-network/keep-core
-cp -R keep-core/solidity/. keep-ecdsa/solidity/node_modules/@keep-network/keep-core
+./scripts/install.sh
 
 printf "${DONE_START}keep-ecdsa deployed successfully!${DONE_END}"

--- a/install-tbtc-dapp.sh
+++ b/install-tbtc-dapp.sh
@@ -11,6 +11,14 @@ WORKDIR=$PWD
 
 printf "${LOG_START}Starting tBTC dApp deployment...${LOG_END}"
 
+printf "${LOG_START}Linking dependencies...${LOG_END}"
+
+cd $WORKDIR/keep-ecdsa/solidity
+npm link
+
+cd $WORKDIR/tbtc/solidity
+npm link
+
 printf "${LOG_START}Install tbtc.js dependencies...${LOG_END}"
 
 cd $WORKDIR/tbtc.js

--- a/install-tbtc-dapp.sh
+++ b/install-tbtc-dapp.sh
@@ -11,33 +11,22 @@ WORKDIR=$PWD
 
 printf "${LOG_START}Starting tBTC dApp deployment...${LOG_END}"
 
-printf "${LOG_START}Preparing tbtc artifacts...${LOG_END}"
-
-cd "$WORKDIR/tbtc/solidity"
-
-ln -sf build/contracts artifacts
-
-printf "${LOG_START}Updating tbtc.js configuration...${LOG_END}"
+printf "${LOG_START}Install tbtc.js dependencies...${LOG_END}"
 
 cd $WORKDIR/tbtc.js
 
-TBTC_DIR="$WORKDIR/tbtc/solidity" jq '.dependencies."@keep-network/tbtc" = env.TBTC_DIR' package.json > package.json.tmp && mv package.json.tmp package.json
-KEEP_ECDSA_DIR="$WORKDIR/keep-ecdsa/solidity" jq '.dependencies."@keep-network/keep-ecdsa" = env.KEEP_ECDSA_DIR' package.json > package.json.tmp && mv package.json.tmp package.json
-
-printf "${LOG_START}Install tbtc.js dependencies...${LOG_END}"
-
 npm install
 
-printf "${LOG_START}Updating tbtc-dapp configuration...${LOG_END}"
+npm link
 
-cd $WORKDIR/tbtc-dapp
-
-TBTC_JS_DIR="$WORKDIR/tbtc.js" jq '.dependencies."@keep-network/tbtc.js" = env.TBTC_JS_DIR' package.json > package.json.tmp && mv package.json.tmp package.json
+npm link @keep-network/keep-ecdsa @keep-network/tbtc
 
 printf "${LOG_START}Install tbtc-dapp dependencies...${LOG_END}"
 
 cd $WORKDIR/tbtc-dapp
 
 npm install
+
+npm link @keep-network/tbtc.js
 
 printf "${DONE_START}tbtc-dapp initialized successfully!${DONE_END}"

--- a/install-tbtc.sh
+++ b/install-tbtc.sh
@@ -39,18 +39,6 @@ if [ "$BTC_NETWORK" == "testnet" ]; then
   jq '.init.bitcoinTest |= fromjson' relay-config.json > relay-config.json.tmp && mv relay-config.json.tmp relay-config.json
 fi
 
-printf "${LOG_START}Preparing keep-ecdsa artifacts...${LOG_END}"
-
-cd "$WORKDIR/keep-ecdsa/solidity"
-
-ln -sf build/contracts artifacts
-
-printf "${LOG_START}Updating tBTC configuration...${LOG_END}"
-
-cd "$WORKDIR/tbtc/solidity"
-
-KEEP_ECDSA_DIR="$WORKDIR/keep-ecdsa/solidity" jq '.dependencies."@keep-network/keep-ecdsa" = env.KEEP_ECDSA_DIR' package.json > package.json.tmp && mv package.json.tmp package.json
-
 printf "${LOG_START}Running install script...${LOG_END}"
 
 cd "$WORKDIR/tbtc"
@@ -58,8 +46,8 @@ cd "$WORKDIR/tbtc"
 # Remove node modules for clean installation
 rm -rf /solidity/node_modules
 
-# Run tBTC install script.  Answer with ENTER on emerging prompt.
-printf '\n' | ./scripts/install.sh
+# Run tBTC install script.
+./scripts/install.sh
 
 cd "$WORKDIR/tbtc/solidity"
 
@@ -75,9 +63,13 @@ printf "${DONE_START}tBTC deployed successfully!${DONE_END}"
 
 printf "${LOG_START}Initializing keep-ecdsa...${LOG_END}"
 
+cd "$WORKDIR/keep-ecdsa/solidity"
+
 # Get network ID.
-NETWORK_ID_OUTPUT=$(npx truffle exec ./scripts/get-network-id.js)
+NETWORK_ID_OUTPUT=$(npx truffle exec ./scripts/get-network-id.js --network local)
 NETWORK_ID=$(echo "$NETWORK_ID_OUTPUT" | tail -1)
+
+printf "${LOG_START}Network ID: ${NETWORK_ID}${LOG_END}"
 
 # Extract TBTCSystem contract address.
 JSON_QUERY=".networks.\"${NETWORK_ID}\".address"
@@ -89,6 +81,6 @@ printf "${LOG_START}TBTCSystem contract address is: ${TBTC_SYSTEM_CONTRACT_ADDRE
 cd "$WORKDIR/keep-ecdsa"
 
 # Run keep-ecdsa initialization script.
-./scripts/initialize.sh --network local --application-address $TBTC_SYSTEM_CONTRACT_ADDRESS
+./scripts/initialize.sh --application-address $TBTC_SYSTEM_CONTRACT_ADDRESS
 
 printf "${DONE_START}keep-ecdsa initialized successfully!${DONE_END}"

--- a/install-tbtc.sh
+++ b/install-tbtc.sh
@@ -41,6 +41,14 @@ fi
 
 printf "${LOG_START}Running install script...${LOG_END}"
 
+printf "${LOG_START}Linking dependencies...${LOG_END}"
+
+cd "$WORKDIR/keep-core/solidity"
+npm link
+
+cd "$WORKDIR/keep-ecdsa/solidity"
+npm link
+
 cd "$WORKDIR/tbtc"
 
 # Remove node modules for clean installation


### PR DESCRIPTION
The installation scripts can work with npm links instead of providing addresses of dependent external contracts in files like `external.js`.

Artifacts directory is created in installation script so we don't need to create it in the scripts in local-setup.

This code depends on couple of other PRs in the modules:
  - https://github.com/keep-network/keep-core/pull/2452
  - https://github.com/keep-network/keep-ecdsa/pull/776
  - https://github.com/keep-network/tbtc/pull/790