### PR TITLE
Modernize the keep-ecdsa Generated Config

### DIFF
--- a/configs/keep-ecdsa/config.local.1.toml
+++ b/configs/keep-ecdsa/config.local.1.toml
@@ -1,8 +1,8 @@
 [ethereum]
-    URL = "ws://127.0.0.1:8546"
+  URL = "ws://127.0.0.1:8546"
 
 [ethereum.account]
-    KeyFile = "WORKDIR/ethereum/data/keystore/UTC--2019-08-01T13-19-33.224673000Z--65849fc91f8289b401e9d8f6d306b814b7f055c3"
+  KeyFile = "WORKDIR/ethereum/data/keystore/UTC--2019-08-01T13-19-33.224673000Z--65849fc91f8289b401e9d8f6d306b814b7f055c3"
 
 [ethereum.ContractAddresses]
   BondedECDSAKeepFactory = "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
@@ -11,7 +11,7 @@
     Addresses = ["0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"]
 
 [Storage]
-    DataDir = "WORKDIR/storage/keep-ecdsa/1"
+  DataDir = "WORKDIR/storage/keep-ecdsa/1"
 
 [LibP2P]
-    Port = 3920
+  Port = 3920

--- a/configs/keep-ecdsa/config.local.1.toml
+++ b/configs/keep-ecdsa/config.local.1.toml
@@ -6,9 +6,8 @@
 
 [ethereum.ContractAddresses]
   BondedECDSAKeepFactory = "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+  TBTCSystem = "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
 
-[SanctionedApplications]
-    Addresses = ["0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"]
 
 [Storage]
   DataDir = "WORKDIR/storage/keep-ecdsa/1"

--- a/configs/keep-ecdsa/config.local.1.toml
+++ b/configs/keep-ecdsa/config.local.1.toml
@@ -8,6 +8,8 @@
   BondedECDSAKeepFactory = "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
   TBTCSystem = "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
 
+[TSS]
+  PreParamsTargetPoolSize = 2
 
 [Storage]
   DataDir = "WORKDIR/storage/keep-ecdsa/1"

--- a/configs/keep-ecdsa/config.local.2.toml
+++ b/configs/keep-ecdsa/config.local.2.toml
@@ -8,6 +8,8 @@
   BondedECDSAKeepFactory = "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
   TBTCSystem = "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
 
+[TSS]
+  PreParamsTargetPoolSize = 2
 
 [Storage]
   DataDir = "WORKDIR/storage/keep-ecdsa/2"

--- a/configs/keep-ecdsa/config.local.2.toml
+++ b/configs/keep-ecdsa/config.local.2.toml
@@ -6,9 +6,8 @@
 
 [ethereum.ContractAddresses]
   BondedECDSAKeepFactory = "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+  TBTCSystem = "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
 
-[SanctionedApplications]
-    Addresses = ["0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"]
 
 [Storage]
   DataDir = "WORKDIR/storage/keep-ecdsa/2"

--- a/configs/keep-ecdsa/config.local.2.toml
+++ b/configs/keep-ecdsa/config.local.2.toml
@@ -1,8 +1,8 @@
 [ethereum]
-    URL = "ws://127.0.0.1:8546"
+  URL = "ws://127.0.0.1:8546"
 
 [ethereum.account]
-    KeyFile = "WORKDIR/ethereum/data/keystore/UTC--2019-08-01T13-19-44.188278000Z--b7021acafecf289fa345ecc95ecab18077530841"
+  KeyFile = "WORKDIR/ethereum/data/keystore/UTC--2019-08-01T13-19-44.188278000Z--b7021acafecf289fa345ecc95ecab18077530841"
 
 [ethereum.ContractAddresses]
   BondedECDSAKeepFactory = "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
@@ -11,8 +11,8 @@
     Addresses = ["0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"]
 
 [Storage]
-    DataDir = "WORKDIR/storage/keep-ecdsa/2"
+  DataDir = "WORKDIR/storage/keep-ecdsa/2"
 
 [LibP2P]
-    Port = 3921
-    Peers = ["/ip4/127.0.0.1/tcp/3920/ipfs/16Uiu2HAmL3fUCp1BCpewHzxcnUf3R1ZoL82CSVVNE6zvi9zUcP1T"]
+  Port = 3921
+  Peers = ["/ip4/127.0.0.1/tcp/3920/ipfs/16Uiu2HAmL3fUCp1BCpewHzxcnUf3R1ZoL82CSVVNE6zvi9zUcP1T"]

--- a/configs/keep-ecdsa/config.local.3.toml
+++ b/configs/keep-ecdsa/config.local.3.toml
@@ -6,9 +6,8 @@
 
 [ethereum.ContractAddresses]
   BondedECDSAKeepFactory = "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+  TBTCSystem = "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
 
-[SanctionedApplications]
-    Addresses = ["0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"]
 
 [Storage]
   DataDir = "WORKDIR/storage/keep-ecdsa/3"

--- a/configs/keep-ecdsa/config.local.3.toml
+++ b/configs/keep-ecdsa/config.local.3.toml
@@ -1,8 +1,8 @@
 [ethereum]
-    URL = "ws://127.0.0.1:8546"
+  URL = "ws://127.0.0.1:8546"
 
 [ethereum.account]
-    KeyFile = "WORKDIR/ethereum/data/keystore/UTC--2019-08-01T13-19-54.505377000Z--28bcfad75ee4c87b9089ba4c03a79b8148104da4"
+  KeyFile = "WORKDIR/ethereum/data/keystore/UTC--2019-08-01T13-19-54.505377000Z--28bcfad75ee4c87b9089ba4c03a79b8148104da4"
 
 [ethereum.ContractAddresses]
   BondedECDSAKeepFactory = "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
@@ -11,8 +11,8 @@
     Addresses = ["0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"]
 
 [Storage]
-    DataDir = "WORKDIR/storage/keep-ecdsa/3"
+  DataDir = "WORKDIR/storage/keep-ecdsa/3"
 
 [LibP2P]
-    Port = 3922
-    Peers = ["/ip4/127.0.0.1/tcp/3920/ipfs/16Uiu2HAmL3fUCp1BCpewHzxcnUf3R1ZoL82CSVVNE6zvi9zUcP1T"]
+  Port = 3922
+  Peers = ["/ip4/127.0.0.1/tcp/3920/ipfs/16Uiu2HAmL3fUCp1BCpewHzxcnUf3R1ZoL82CSVVNE6zvi9zUcP1T"]

--- a/configs/keep-ecdsa/config.local.3.toml
+++ b/configs/keep-ecdsa/config.local.3.toml
@@ -8,6 +8,8 @@
   BondedECDSAKeepFactory = "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
   TBTCSystem = "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
 
+[TSS]
+  PreParamsTargetPoolSize = 2
 
 [Storage]
   DataDir = "WORKDIR/storage/keep-ecdsa/3"


### PR DESCRIPTION
Three main changes:

* We unify on 2-space tabs (I don't personally care here, just need for it to be consistent so I can tell my editor what to do)
* We move the TBTCSystem address to `ethereum.ContractAddresses.TBTCSystem` as per the deprecation warnings:
```
			"TBTCSystem address configuration in SanctionedApplications.Addresses " +
				"is DEPRECATED and will be removed. Please configure the " +
				"TBTCSystem address alongside BondedECDSAKeep under " +
				"Ethereum.ContractAddresses.",
```
* We add in a default-override for `TSS. PreParamsTargetPoolSize` to facilitate local development/testing. Having a higher number hurts iteration time and some machines will run out of memory or get cpu-locked trying to compute more pre-params.
