### PR TITLE
Remove trailingComma: "all" from the prettier config

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Remove trailing commas from local-setup js files
+05920f98f42fea2df10784adf7a3c39e24f6424c

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,2 +1,4 @@
+#check https://github.com/keep-network/eslint-config-keep/blob/master/index.js
+#for the correct prettier config used across keep projects
+#FIXME: use the cross-repo config
 semi: false
-trailingComma: "all"

--- a/common.js/src/contracts.js
+++ b/common.js/src/contracts.js
@@ -20,7 +20,7 @@ const { resolve } = require("path")
 function readExternalContractAddress(
   packageName,
   contractName,
-  deployerOrNetworkID,
+  deployerOrNetworkID
 ) {
   let networkID
   // Support truffle's deployer object used in migrations.
@@ -33,7 +33,7 @@ function readExternalContractAddress(
   let artifactRaw
   try {
     artifactRaw = readFileSync(
-      resolve(`./node_modules/${packageName}/artifacts/${contractName}.json`),
+      resolve(`./node_modules/${packageName}/artifacts/${contractName}.json`)
     )
   } catch (err) {
     throw new Error(`failed to read artifact file: ${err.message}`)
@@ -48,13 +48,13 @@ function readExternalContractAddress(
 
   if (!artifact.networks[networkID]) {
     throw new Error(
-      `configuration for network ${networkID} not found in ${contractName}`,
+      `configuration for network ${networkID} not found in ${contractName}`
     )
   }
 
   if (!artifact.networks[networkID].address) {
     throw new Error(
-      `missing address for network ${networkID} in ${contractName}`,
+      `missing address for network ${networkID} in ${contractName}`
     )
   }
 

--- a/common.js/test/contracts.test.js
+++ b/common.js/test/contracts.test.js
@@ -11,7 +11,7 @@ describe("Contracts", function () {
 
     before(function () {
       const testFile = resolve(
-        `./node_modules/${packageName}/artifacts/${contractName}.json`,
+        `./node_modules/${packageName}/artifacts/${contractName}.json`
       )
 
       mkdirSync(dirname(testFile), { recursive: true })
@@ -21,11 +21,11 @@ describe("Contracts", function () {
 
     it("reads addresses from test file", async () => {
       expect(
-        readExternalContractAddress(packageName, contractName, "1707"),
+        readExternalContractAddress(packageName, contractName, "1707")
       ).to.equal("0xa90505c0EC23F776631557143ABF3ff5602D0947")
 
       expect(
-        readExternalContractAddress(packageName, contractName, "2"),
+        readExternalContractAddress(packageName, contractName, "2")
       ).to.equal("0xEDDD3D1737021e3B716FE88433c1382D9eBCEF76")
     })
 
@@ -33,31 +33,31 @@ describe("Contracts", function () {
       expect(
         readExternalContractAddress(packageName, contractName, {
           network_id: "1707",
-        }),
+        })
       ).to.equal("0xa90505c0EC23F776631557143ABF3ff5602D0947")
     })
 
     it("throws an error if address is missing", async () => {
       expect(() =>
-        readExternalContractAddress(packageName, contractName, "13"),
+        readExternalContractAddress(packageName, contractName, "13")
       ).to.throw(Error, "missing address for network 13 in TestContract")
     })
 
     it("throws an error if network is missing", async () => {
       expect(() =>
-        readExternalContractAddress(packageName, contractName, "777"),
+        readExternalContractAddress(packageName, contractName, "777")
       ).to.throw(
         Error,
-        "configuration for network 777 not found in TestContract",
+        "configuration for network 777 not found in TestContract"
       )
     })
 
     it("throws an error if contract artifact is missing", async () => {
       expect(() =>
-        readExternalContractAddress(packageName, "MissingContract", "1"),
+        readExternalContractAddress(packageName, "MissingContract", "1")
       ).to.throw(
         Error,
-        "failed to read artifact file: ENOENT: no such file or directory",
+        "failed to read artifact file: ENOENT: no such file or directory"
       )
     })
   })

--- a/inspector/scripts/inspect-beacon.js
+++ b/inspector/scripts/inspect-beacon.js
@@ -3,18 +3,18 @@ const KeepRandomBeaconOperatorJson = require("@keep-network/keep-core/artifacts/
 
 const contractHelper = require("./lib/contract-helper")
 
-const abiDecoder = require('abi-decoder');
+const abiDecoder = require("abi-decoder")
 abiDecoder.addABI(KeepRandomBeaconOperatorJson.abi)
 
 module.exports = async function () {
   try {
     const deploymentBlock = await contractHelper.getDeploymentBlockNumber(
       KeepRandomBeaconOperatorJson,
-      web3,
+      web3
     )
 
     const KeepRandomBeaconOperator = truffleContract(
-      KeepRandomBeaconOperatorJson,
+      KeepRandomBeaconOperatorJson
     )
     KeepRandomBeaconOperator.setProvider(web3.currentProvider)
 
@@ -26,21 +26,21 @@ module.exports = async function () {
       {
         fromBlock: deploymentBlock,
         toBlock: "latest",
-      },
+      }
     )
     const entrySubmittedEvents = await keepRandomBeaconOperator.getPastEvents(
       "RelayEntrySubmitted",
       {
         fromBlock: deploymentBlock,
         toBlock: "latest",
-      },
+      }
     )
     const timeoutEvents = await keepRandomBeaconOperator.getPastEvents(
       "RelayEntryTimeoutReported",
       {
         fromBlock: deploymentBlock,
         toBlock: "latest",
-      },
+      }
     )
 
     console.log(`Number of groups:            ${numberOfGroups}`)
@@ -54,7 +54,7 @@ module.exports = async function () {
       {
         fromBlock: deploymentBlock,
         toBlock: "latest",
-      },
+      }
     )
 
     const allOperators = new Set()
@@ -62,7 +62,7 @@ module.exports = async function () {
     for (i = 0; i < numberOfGroups; i++) {
       const groupPubKey = await keepRandomBeaconOperator.getGroupPublicKey(i)
       const groupMembers = await keepRandomBeaconOperator.getGroupMembers(
-        groupPubKey,
+        groupPubKey
       )
 
       const uniqueMembers = new Set()

--- a/inspector/scripts/inspect-ecdsa-keep.js
+++ b/inspector/scripts/inspect-ecdsa-keep.js
@@ -13,7 +13,7 @@ module.exports = async function () {
 
     const factoryDeploymentBlock = await contractHelper.getDeploymentBlockNumber(
       BondedECDSAKeepFactoryJson,
-      web3,
+      web3
     )
 
     const factory = await BondedECDSAKeepFactory.deployed()
@@ -37,7 +37,7 @@ module.exports = async function () {
         {
           fromBlock: factoryDeploymentBlock,
           toBlock: "latest",
-        },
+        }
       )
 
       console.log(`keep address:        ${keepAddress}`)
@@ -53,7 +53,7 @@ module.exports = async function () {
         console.log(`signature requested: no`)
       } else {
         console.log(
-          `signature requested: yes, [${signatureRequestedEvents.length}] times`,
+          `signature requested: yes, [${signatureRequestedEvents.length}] times`
         )
 
         const signatureSubmittedEvents = await keep.getPastEvents(
@@ -61,13 +61,13 @@ module.exports = async function () {
           {
             fromBlock: factoryDeploymentBlock,
             toBlock: "latest",
-          },
+          }
         )
         if (signatureRequestedEvents.length == 0) {
           console.log(`signature submitted: no`)
         } else {
           console.log(
-            `signature submitted: yes, [${signatureSubmittedEvents.length}] times`,
+            `signature submitted: yes, [${signatureSubmittedEvents.length}] times`
           )
         }
       }
@@ -89,8 +89,8 @@ module.exports = async function () {
     }
     console.log(
       `potentially bad operators = ${new Array(...potentiallyBadOperators).join(
-        ", ",
-      )}`,
+        ", "
+      )}`
     )
 
     process.exit()

--- a/inspector/scripts/inspect-operators.js
+++ b/inspector/scripts/inspect-operators.js
@@ -22,7 +22,7 @@ module.exports = async function () {
     const TokenStaking = truffleContract(TokenStakingJson)
     const KeepBonding = truffleContract(KeepBondingJson)
     const KeepRandomBeaconOperator = truffleContract(
-      KeepRandomBeaconOperatorJson,
+      KeepRandomBeaconOperatorJson
     )
     const BondedECDSAKeepFactory = truffleContract(BondedECDSAKeepFactoryJson)
     const TBTCSystem = truffleContract(TBTCSystemJson)
@@ -51,12 +51,12 @@ module.exports = async function () {
     console.log(``)
 
     const beaconOperators = beaconNodes.connected_peers.map(
-      (peer) => peer.ethereum_address,
+      (peer) => peer.ethereum_address
     )
     console.log(
       clc.italic(
-        `Fetching staking info for [${beaconOperators.length}] beacon operators...`,
-      ),
+        `Fetching staking info for [${beaconOperators.length}] beacon operators...`
+      )
     )
     console.log(``)
 
@@ -66,7 +66,7 @@ module.exports = async function () {
 
       const eligibleStake = await tokenStaking.eligibleStake(
         operator,
-        keepRandomBeaconOperator.address,
+        keepRandomBeaconOperator.address
       )
       const eligibleStakeKeep = eligibleStake.div(tokenDecimalMultiplier)
 
@@ -84,8 +84,8 @@ module.exports = async function () {
     if (process.env.OUTPUT_MODE === "text") {
       beaconSummary.forEach((s) =>
         console.log(
-          `${s.address}    ${s.eligibleStakeKeep}    ${s.operatorBalanceEth}`,
-        ),
+          `${s.address}    ${s.eligibleStakeKeep}    ${s.operatorBalanceEth}`
+        )
       )
     } else {
       console.table(beaconSummary)
@@ -93,12 +93,12 @@ module.exports = async function () {
     console.log(``)
 
     const ecdsaOperators = ecdsaNodes.connected_peers.map(
-      (peer) => peer.ethereum_address,
+      (peer) => peer.ethereum_address
     )
     console.log(
       clc.italic(
-        `Fetching staking info for [${ecdsaOperators.length}] ECDSA operators...`,
-      ),
+        `Fetching staking info for [${ecdsaOperators.length}] ECDSA operators...`
+      )
     )
     console.log(``)
 
@@ -108,7 +108,7 @@ module.exports = async function () {
 
       const eligibleStake = await tokenStaking.eligibleStake(
         operator,
-        keepRandomBeaconOperator.address,
+        keepRandomBeaconOperator.address
       )
       const eligibleStakeKeep = eligibleStake.div(tokenDecimalMultiplier)
 
@@ -120,14 +120,14 @@ module.exports = async function () {
 
       const isRegisteredInTbtcPool = await bondedEcdsaKeepFactory.isOperatorRegistered(
         operator,
-        tbtcSystem.address,
+        tbtcSystem.address
       )
 
       let isUpToDateInTbtcPool
       if (isRegisteredInTbtcPool) {
         isUpToDateInTbtcPool = await bondedEcdsaKeepFactory.isOperatorUpToDate(
           operator,
-          tbtcSystem.address,
+          tbtcSystem.address
         )
       } else {
         isUpToDateInTbtcPool = "N/A"
@@ -148,8 +148,8 @@ module.exports = async function () {
       ecdsaSummary.forEach((s) =>
         console.log(
           `${s.address}    ${s.eligibleStakeKeep}    ${s.operatorBalanceEth}    ` +
-            `${s.unbondedValueEth}    ${s.isRegisteredInTbtcPool}    ${s.isUpToDateInTbtcPool}`,
-        ),
+            `${s.unbondedValueEth}    ${s.isRegisteredInTbtcPool}    ${s.isUpToDateInTbtcPool}`
+        )
       )
     } else {
       console.table(ecdsaSummary)

--- a/inspector/scripts/inspect-tbtc.js
+++ b/inspector/scripts/inspect-tbtc.js
@@ -9,7 +9,7 @@ module.exports = async function () {
   try {
     const factoryDeploymentBlock = await contractHelper.getDeploymentBlockNumber(
       DepositFactoryJson,
-      web3,
+      web3
     )
 
     const TbtcSystem = truffleContract(TbtcSystemJson)
@@ -27,14 +27,14 @@ module.exports = async function () {
       {
         fromBlock: factoryDeploymentBlock,
         toBlock: "latest",
-      },
+      }
     )
 
     console.log(`Number of created deposits: ${depositCreatedEvents.length} \n`)
 
     const depositAddresses = []
     depositCreatedEvents.forEach((event) =>
-      depositAddresses.push(event.args.depositCloneAddress),
+      depositAddresses.push(event.args.depositCloneAddress)
     )
 
     for (i = 0; i < depositAddresses.length; i++) {
@@ -87,13 +87,13 @@ module.exports = async function () {
       const lotSizeTbtc = await deposit.lotSizeTbtc()
 
       const pubKeyRegisteredEvents = await tbtcSystem.getPastEvents(
-        "RegisteredPubkey",        
+        "RegisteredPubkey",
         {
           filter: {
-            _depositContractAddress: deposit.address
+            _depositContractAddress: deposit.address,
           },
           fromBlock: factoryDeploymentBlock,
-          toBlock: "latest"
+          toBlock: "latest",
         }
       )
       const pubKeyRegistered = pubKeyRegisteredEvents.length > 0


### PR DESCRIPTION
Our other projects don't include `trailingComma: "all"` in their prettier configs, so we remove it here and then re-run the prettier command.

This was the bottom of a rabbit hole, but I wanted to change `keep-ecdsa/solidity/scripts/lcl-client-config.js`. Changing that triggered the javascript linting job, which showed that there were a bunch of missing commas and wouldn't let me commit. I opened a separate PR to lint the ecdsa client: https://github.com/keep-network/keep-ecdsa/pull/779, but that PR didn't match with the lint reports from the linting job.

After a significant amount of debugging, it turns out that the linting job in github had a clean `.prettierrc`, and my development machine's ecdsa lint configuration was inheriting from this `local-setup`'s config. The near-term solution is to standardize local-setup's config. Longer term (and in a separate PR) is to find a way to point all of the projects configuration at a single file.

Tagging @Shadowfiend for review