### PR TITLE
Updated geth to 1.10.3-991384a7

### DIFF
--- a/deployments/local-setup-environment/provisioning/install-geth.sh
+++ b/deployments/local-setup-environment/provisioning/install-geth.sh
@@ -4,7 +4,7 @@ set -e
 
 echo "Installing go-ethereum..."
 
-GETH_PACKAGE=geth-alltools-linux-amd64-1.9.9-01744997.tar.gz
+GETH_PACKAGE=geth-alltools-linux-amd64-1.10.3-991384a7.tar.gz
 
 curl -O https://gethstore.blob.core.windows.net/builds/$GETH_PACKAGE
 

--- a/docs/manual-setup.adoc
+++ b/docs/manual-setup.adoc
@@ -6,7 +6,7 @@ If you’re on macOS, install Homebrew and https://github.com/keep-network/keep-
 If you are not on macOS or you don't have Homebrew, you need to install:
 
 - Go compiler, at least 1.14
-- Geth (Ethereum client) 1.9.9-stable
+- Geth (Ethereum client) 1.10.3-stable
 - Solidity, at least 0.5.17
 - Protobuf compiler, at least 3.11.4
 - `protoc-gen-gogoslick` toolchain

--- a/run-geth.sh
+++ b/run-geth.sh
@@ -21,4 +21,7 @@ geth --port 0 --networkid 1101 --identity "somerandomidentity" \
     --datadir=$GETH_DATA_DIR --syncmode "fast" \
     --miner.etherbase=$GETH_ETHEREUM_ACCOUNT --mine --miner.threads=1 \
     --unlock $GETH_ETHEREUM_ACCOUNT --password <(echo "password") \
-    --allow-insecure-unlock
+    --allow-insecure-unlock \
+    --rpc.allow-unprotected-txs \
+    --snapshot=false \
+    --nodiscover --maxpeers 0

--- a/run-geth.sh
+++ b/run-geth.sh
@@ -14,10 +14,10 @@ printf "${LOG_START}Starting geth...${LOG_END}"
 # --unlock unlocks the signer account for proof of authority block signing,
 # otherwise we can't run the network <_<
 geth --port 0 --networkid 1101 --identity "somerandomidentity" \
-    --ws --wsaddr "127.0.0.1" --wsport "8546" --wsorigins "*" \
-    --rpc --rpcport "8545" --rpcaddr "127.0.0.1" --rpccorsdomain "*" \
-    --rpcapi "db,ssh,miner,admin,eth,net,web3,personal,debug" \
-    --wsapi "db,ssh,miner,admin,eth,net,web3,personal,debug" \
+    --ws --ws.addr "127.0.0.1" --ws.port "8546" --ws.origins "*" \
+    --http --http.port "8545" --http.addr "127.0.0.1" --http.corsdomain "*" \
+    --http.api "db,ssh,miner,admin,eth,net,web3,personal,debug" \
+    --ws.api "db,ssh,miner,admin,eth,net,web3,personal,debug" \
     --datadir=$GETH_DATA_DIR --syncmode "fast" \
     --miner.etherbase=$GETH_ETHEREUM_ACCOUNT --mine --miner.threads=1 \
     --unlock $GETH_ETHEREUM_ACCOUNT --password <(echo "password") \


### PR DESCRIPTION
In this PR we update the version of geth to 1.10.3-991384a7.
Geth command start API has changed in 1.10.3 so we need to tweak the names of passed arguments.
We also added more flags to geth run command to stabilize the private chain instance of the geth we're running.

Please see commits description for more details.