### PR TITLE
No longer append GITHUB_PATH with `/usr/local/go/bin`

### DIFF
--- a/.github/workflows/e2e-local.yml
+++ b/.github/workflows/e2e-local.yml
@@ -43,7 +43,6 @@ jobs:
           echo "Using Go: $(go version)"
           echo "GOPATH=$HOME/go" >> $GITHUB_ENV
           echo "$HOME/go/bin" >> $GITHUB_PATH
-          echo "/usr/local/go/bin" >> $GITHUB_PATH
          
       - name: Install Geth
         working-directory: ./deployments/local-setup-environment/provisioning/


### PR DESCRIPTION
The step appending `GITHUB_PATH` with `/usr/local/go/bin` was
unnecessary. Only `GOPATH=$HOME/go` needs to be added to `GITHUB_PATH`.