### PR TITLE
bitcoind-wallet: Let to select address type for getNewAddress

### DIFF
--- a/bitcoind-wallet/bin/cli.js
+++ b/bitcoind-wallet/bin/cli.js
@@ -11,7 +11,8 @@ const cli = meow(`
 
   Commands
     sendToAddress         [address] [btc] Send btc to an address
-    getNewAddress         Get an address to receive btc
+    getNewAddress         [addressType=bech32] Get an address to receive btc (optional)
+                            Values: legacy, p2sh-segwit, bech32
     sendRawTransaction    [transaction] Broadcast a raw transaction
     getBalance            [address] Get the balance of an address
 `)
@@ -21,7 +22,7 @@ const [cmd, ...args] = cli.input
 if (cmd === 'sendToAddress') {
   sendToAddress(...args)
 } else if (cmd === 'getNewAddress') {
-  getNewAddress()
+  getNewAddress(...args)
 } else if (cmd === 'sendRawTransaction') {
   sendRawTransaction(...args)
 } else if (cmd === 'getBalance') {

--- a/bitcoind-wallet/index.js
+++ b/bitcoind-wallet/index.js
@@ -9,8 +9,14 @@ export async function sendToAddress(address, btc) {
   return bitcoinRpc.sendtoaddressAsync(address, btc)
 }
 
-export async function getNewAddress() {
-  const address = (await bitcoinRpc.getnewaddressAsync()).result
+/**
+ * Returns a new Bitcoin address for receiving payments.
+ * @param {string} [addressType=bech32] The address type to use. Options are:
+ * legacy, p2sh-segwit, and bech32.
+ * @returns {string} Address.
+ */
+export async function getNewAddress(addressType = "bech32") {
+  const address = (await bitcoinRpc.getnewaddressAsync("", addressType)).result
   console.log(address)
   return address
 }


### PR DESCRIPTION
bitcoind-rpc API allows selection of the address type to generate.
Options are: legacy, p2sh-segwit, and bech32. Default is bech32.
Here we enhance CLI command to let the user select the address type.

Ref: https://developer.bitcoin.org/reference/rpc/getnewaddress.html