### PR TITLE
Reformat The Command List in bitcoind-wallet CLI

### DIFF
--- a/bitcoind-wallet/bin/cli.js
+++ b/bitcoind-wallet/bin/cli.js
@@ -10,11 +10,11 @@ const cli = meow(`
     $ bitcoind-wallet <command> <arg...>
 
   Commands
-    sendToAddress         [address] [btc] Send btc to an address
-    getNewAddress         [addressType=bech32] Get an address to receive btc (optional)
-                            Values: legacy, p2sh-segwit, bech32
-    sendRawTransaction    [transaction] Broadcast a raw transaction
-    getBalance            [address] Get the balance of an address
+    sendToAddress         <address> <btc> Send btc to an address
+    getNewAddress         [address_type] Get an address to receive btc
+                            Values: legacy, p2sh-segwit, bech32 (default)
+    sendRawTransaction    <transaction> Broadcast a raw transaction
+    getBalance            <address> Get the balance of an address
 `)
 
 const [cmd, ...args] = cli.input


### PR DESCRIPTION
This PR implements the suggestions in https://github.com/keep-network/local-setup/pull/95#discussion_r652697412 which attempts to standardize our command list instructions with those presented in https://en.wikipedia.org/wiki/Usage_message and https://developers.google.com/style/code-syntax

Tagging @nkuba for review