### PR TITLE
Migrate from `master` to `main` branch

### DIFF
--- a/.github/workflows/bitcoin.yml
+++ b/.github/workflows/bitcoin.yml
@@ -3,7 +3,7 @@ name: bitcoin
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - "bitcoin/**"
   pull_request:

--- a/.github/workflows/common-js.yml
+++ b/.github/workflows/common-js.yml
@@ -3,7 +3,7 @@ name: common.js
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - "common.js/**"
   pull_request:
@@ -77,7 +77,7 @@ jobs:
   # common-js-publish:
   #   needs: [common-js-test, common-js-lint]
   #   if:
-  #     github.ref == 'refs/heads/master'
+  #     github.ref == 'refs/heads/main'
   #       && github.event_name != 'pull_request' 
   #   runs-on: ubuntu-latest
   #   steps:

--- a/docs/auto-setup.adoc
+++ b/docs/auto-setup.adoc
@@ -42,7 +42,7 @@ A new virtual machine will be created and provisioned accordingly. When
 this command terminates successfully, the machine should be ready to work
 and have all the auxiliary software like Geth, Bitcoin Core, ElectrumX
 and Core/ECDSA clients running. Worth noting, `keep-core` and `keep-ecdsa` client
-executables are always built from their recent master versions.
+executables are always built from their recent main versions.
 
 == How to interact with the system
 

--- a/docs/manual-setup.adoc
+++ b/docs/manual-setup.adoc
@@ -1,7 +1,7 @@
 = Manual setup on local machine
 
 == Prerequisites
-If you’re on macOS, install Homebrew and https://github.com/keep-network/keep-core/blob/master/scripts/macos-setup.sh[macos-setup.sh] script to setup all necessary tools.
+If you’re on macOS, install Homebrew and https://github.com/keep-network/keep-core/blob/main/scripts/macos-setup.sh[macos-setup.sh] script to setup all necessary tools.
 
 If you are not on macOS or you don't have Homebrew, you need to install:
 

--- a/inspector/package.json
+++ b/inspector/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "repository": {
     "type": "git",
-    "url": "https://github.com/keep-network/local-setup/tree/master/inspector"
+    "url": "https://github.com/keep-network/local-setup/tree/main/inspector"
   },
   "dependencies": {
     "@keep-network/keep-core": "1.3.0",


### PR DESCRIPTION
Use of the `master` and `slave` terms in the computer industry is
widespread, but has been recently discouraged, as it was brought to
attention that the terms may be considered offensive.
GitHub has already moved their default repositories from the `master`
to `main` in many places. We're planning to do the same for our
repositories, this however requires some changes in the code.
After the proposed changes get merged to the `master` branch, the
repository should be ready for the migration from `master` to `main`.

To migrate from `master` to `main`:
1. Do a local branch rename with `git branch -m master main`
2. Push the renamed branch `git push -u origin main`
3. In the Github repo settings, rename the default branch: Settings ->
    Branches -> Default branch -> (pencil icon) -> (change `master` to
    `main`) -> (approve)

After migration other contributors should update their local repositories:
```
git branch -m master main
git fetch origin
git branch -u origin/main main
git remote set-head origin -a
```

Refs:
https://github.com/keep-network/keep-core/pull/2521
https://github.com/keep-network/keep-ecdsa/pull/845
https://github.com/keep-network/tbtc/pull/810
https://github.com/keep-network/tbtc-dapp/pull/399
https://github.com/keep-network/tbtc.js/pull/126
https://github.com/keep-network/keep-common/pull/79
https://github.com/keep-network/sortition-pools/pull/113
https://github.com/keep-network/ci/pull/8
https://github.com/keep-network/run-workflow/pull/3
https://github.com/keep-network/notify-workflow-completed/pull/3
https://github.com/keep-network/load-env-variables/pull/2