### PR TITLE
Liquidation Recovery Config Automation

### DIFF
--- a/configs/keep-ecdsa/config.local.1.toml
+++ b/configs/keep-ecdsa/config.local.1.toml
@@ -8,6 +8,14 @@
   BondedECDSAKeepFactory = "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
   TBTCSystem = "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
 
+[Extensions.TBTC]
+  LiquidationRecoveryTimeout = "48h"
+
+[Extensions.TBTC.Bitcoin]
+  BeneficiaryAddress = "BENEFICIARY_ADDRESS"
+  BitcoinChainName = "regtest"
+  ElectrsURL = "http://localhost:3002"
+
 [TSS]
   PreParamsTargetPoolSize = 2
 

--- a/configs/keep-ecdsa/config.local.2.toml
+++ b/configs/keep-ecdsa/config.local.2.toml
@@ -8,6 +8,14 @@
   BondedECDSAKeepFactory = "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
   TBTCSystem = "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
 
+[Extensions.TBTC]
+  LiquidationRecoveryTimeout = "48h"
+
+[Extensions.TBTC.Bitcoin]
+  BeneficiaryAddress = "BENEFICIARY_ADDRESS"
+  BitcoinChainName = "regtest"
+  ElectrsURL = "http://localhost:3002"
+
 [TSS]
   PreParamsTargetPoolSize = 2
 

--- a/configs/keep-ecdsa/config.local.3.toml
+++ b/configs/keep-ecdsa/config.local.3.toml
@@ -8,6 +8,14 @@
   BondedECDSAKeepFactory = "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
   TBTCSystem = "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
 
+[Extensions.TBTC]
+  LiquidationRecoveryTimeout = "48h"
+
+[Extensions.TBTC.Bitcoin]
+  BeneficiaryAddress = "BENEFICIARY_ADDRESS"
+  BitcoinChainName = "regtest"
+  ElectrsURL = "http://localhost:3002"
+
 [TSS]
   PreParamsTargetPoolSize = 2
 

--- a/docs/manual-setup.adoc
+++ b/docs/manual-setup.adoc
@@ -49,6 +49,13 @@ You can skip this step if your local geth is already initialized. This script cl
 ```
 $ ./run-geth.sh
 ```
+. Initialize bitcoin using:
++
+```
+$ ./initialize-bitcoin.sh
+```
+You can skip this step if your local bitcoin is alread initialized.
+
 . Run local Bitcoin Core node and ElectrumX using:
 +
 ```

--- a/initialize-bitcoin.sh
+++ b/initialize-bitcoin.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+LOG_START='\n\e[1;36m' # new line + bold + color
+LOG_END='\n\e[0m' # new line + reset color
+DONE_START='\n\e[1;32m' # new line + bold + green
+DONE_END='\n\n\e[0m'    # new line + reset
+
+WORKDIR=$PWD
+
+printf "${LOG_START}Installing bitcoind-wallet...${LOG_END}"
+
+npm install -g "$WORKDIR/bitcoind-wallet"
+
+printf "${LOG_START}Bitcoin initialization complete!${LOG_END}"

--- a/install-keep-ecdsa.sh
+++ b/install-keep-ecdsa.sh
@@ -9,6 +9,10 @@ DONE_END='\n\n\e[0m'    # new line + reset
 
 WORKDIR=$PWD
 
+printf "${LOG_START}Installing bitcoind-wallet...${LOG_END}"
+
+npm install -g "$WORKDIR/bitcoind-wallet"
+
 printf "${LOG_START}Starting keep-ecdsa deployment...${LOG_END}"
 
 printf "${LOG_START}Copying config files...${LOG_END}"
@@ -21,14 +25,26 @@ cd keep-ecdsa/configs
 # Fill absolute paths in config files with actual working directory.
 TMP_FILE=$(mktemp /tmp/config.local.1.toml.XXXXXXXXXX)
 sed 's:WORKDIR:'$WORKDIR':' config.local.1.toml > $TMP_FILE
+# Generate a new btc wallet address
+BENEFICIARY_ADDRESS=$(NODE_NO_WARNINGS=1 bitcoind-wallet getNewAddress | sed 's/ *$//g')
+# Set the address at Extensions.TBTC.Bitcoin.BeneficiaryAddress
+sed -i '' "s/BENEFICIARY_ADDRESS/$BENEFICIARY_ADDRESS/g" $TMP_FILE
 mv $TMP_FILE config.local.1.toml
 
 TMP_FILE=$(mktemp /tmp/config.local.2.toml.XXXXXXXXXX)
 sed 's:WORKDIR:'$WORKDIR':' config.local.2.toml > $TMP_FILE
+# Generate a new btc wallet address
+BENEFICIARY_ADDRESS=$(NODE_NO_WARNINGS=1 bitcoind-wallet getNewAddress | sed 's/ *$//g')
+# Set the address at Extensions.TBTC.Bitcoin.BeneficiaryAddress
+sed -i '' "s/BENEFICIARY_ADDRESS/$BENEFICIARY_ADDRESS/g" $TMP_FILE
 mv $TMP_FILE config.local.2.toml
 
 TMP_FILE=$(mktemp /tmp/config.local.3.toml.XXXXXXXXXX)
 sed 's:WORKDIR:'$WORKDIR':' config.local.3.toml > $TMP_FILE
+# Generate a new btc wallet address
+BENEFICIARY_ADDRESS=$(NODE_NO_WARNINGS=1 bitcoind-wallet getNewAddress | sed 's/ *$//g')
+# Set the address at Extensions.TBTC.Bitcoin.BeneficiaryAddress
+sed -i '' "s/BENEFICIARY_ADDRESS/$BENEFICIARY_ADDRESS/g" $TMP_FILE
 mv $TMP_FILE config.local.3.toml
 
 printf "${LOG_START}Creating storage directories...${LOG_END}"

--- a/install-keep-ecdsa.sh
+++ b/install-keep-ecdsa.sh
@@ -9,10 +9,6 @@ DONE_END='\n\n\e[0m'    # new line + reset
 
 WORKDIR=$PWD
 
-printf "${LOG_START}Installing bitcoind-wallet...${LOG_END}"
-
-npm install -g "$WORKDIR/bitcoind-wallet"
-
 printf "${LOG_START}Starting keep-ecdsa deployment...${LOG_END}"
 
 printf "${LOG_START}Copying config files...${LOG_END}"


### PR DESCRIPTION
This PR adds automation to the local `./install.sh` script to populate the keep-ecdsa configs with the relevant configuration bits for liquidation recovery. This allows developers to run a fully configured node for liquidation recovery. This will be mostly useless until either the liquidation-recovery-integration branch is merged in `keep-ecdsa` or if a developer is manually checking out that branch for local builds.

Tagging @nkuba for review