### PR TITLE
Fix the passing of options in shebang line

### DIFF
--- a/bitcoind-wallet/bin/cli.js
+++ b/bitcoind-wallet/bin/cli.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --experimental-modules --experimental-json-modules
+#!/usr/bin/env -S node --experimental-modules --experimental-json-modules
 
 import { createRequire } from "module"
 import { sendToAddress, getNewAddress, sendRawTransaction, getBalance } from "./../index.js"


### PR DESCRIPTION
Without the change, the `keep-ecdsa` startup during execution of `E2E
tests / Locally` workflow was failing with the following error:
```
/usr/bin/env: ‘node --experimental-modules
               --experimental-json-modules’: No such file or directory
/usr/bin/env: use -[v]S to pass options in shebang lines
sed: can't read s/BENEFICIARY_ADDRESS//g: No such file or directory
```