### PR TITLE
Fix issues with `sed` command and Go version in the E2E tests script

### DIFF
--- a/.github/workflows/e2e-local.yml
+++ b/.github/workflows/e2e-local.yml
@@ -34,13 +34,14 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
-          
-      - name: Install Go
-        working-directory: ./deployments/local-setup-environment/provisioning/
+
+      - name: Set up Go 1.16
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.16
+
+      - name: Set up Go environment variables
         run: |
-          sudo rm -rf /usr/local/go
-          ./install-go.sh
-          echo "Using Go: $(go version)"
           echo "GOPATH=$HOME/go" >> $GITHUB_ENV
           echo "$HOME/go/bin" >> $GITHUB_PATH
          

--- a/install-keep-ecdsa.sh
+++ b/install-keep-ecdsa.sh
@@ -18,29 +18,22 @@ cp -R configs/keep-ecdsa/. keep-ecdsa/configs/
 
 cd keep-ecdsa/configs
 
-# Fill absolute paths in config files with actual working directory.
-TMP_FILE=$(mktemp /tmp/config.local.1.toml.XXXXXXXXXX)
-sed 's:WORKDIR:'$WORKDIR':' config.local.1.toml > $TMP_FILE
-# Generate a new btc wallet address
+# Fill absolute paths in config files with actual working directory, generate
+# a new btc wallet address and set the address at
+# Extensions.TBTC.Bitcoin.BeneficiaryAddress
 BENEFICIARY_ADDRESS=$(NODE_NO_WARNINGS=1 bitcoind-wallet getNewAddress | sed 's/ *$//g')
-# Set the address at Extensions.TBTC.Bitcoin.BeneficiaryAddress
-sed -i '' "s/BENEFICIARY_ADDRESS/$BENEFICIARY_ADDRESS/g" $TMP_FILE
+TMP_FILE=$(mktemp /tmp/config.local.1.toml.XXXXXXXXXX)
+sed 's:WORKDIR:'$WORKDIR':g;s:BENEFICIARY_ADDRESS:'$BENEFICIARY_ADDRESS':g' config.local.1.toml > $TMP_FILE
 mv $TMP_FILE config.local.1.toml
 
-TMP_FILE=$(mktemp /tmp/config.local.2.toml.XXXXXXXXXX)
-sed 's:WORKDIR:'$WORKDIR':' config.local.2.toml > $TMP_FILE
-# Generate a new btc wallet address
 BENEFICIARY_ADDRESS=$(NODE_NO_WARNINGS=1 bitcoind-wallet getNewAddress | sed 's/ *$//g')
-# Set the address at Extensions.TBTC.Bitcoin.BeneficiaryAddress
-sed -i '' "s/BENEFICIARY_ADDRESS/$BENEFICIARY_ADDRESS/g" $TMP_FILE
+TMP_FILE=$(mktemp /tmp/config.local.2.toml.XXXXXXXXXX)
+sed 's:WORKDIR:'$WORKDIR':g;s:BENEFICIARY_ADDRESS:'$BENEFICIARY_ADDRESS':g' config.local.2.toml > $TMP_FILE
 mv $TMP_FILE config.local.2.toml
 
-TMP_FILE=$(mktemp /tmp/config.local.3.toml.XXXXXXXXXX)
-sed 's:WORKDIR:'$WORKDIR':' config.local.3.toml > $TMP_FILE
-# Generate a new btc wallet address
 BENEFICIARY_ADDRESS=$(NODE_NO_WARNINGS=1 bitcoind-wallet getNewAddress | sed 's/ *$//g')
-# Set the address at Extensions.TBTC.Bitcoin.BeneficiaryAddress
-sed -i '' "s/BENEFICIARY_ADDRESS/$BENEFICIARY_ADDRESS/g" $TMP_FILE
+TMP_FILE=$(mktemp /tmp/config.local.3.toml.XXXXXXXXXX)
+sed 's:WORKDIR:'$WORKDIR':g;s:BENEFICIARY_ADDRESS:'$BENEFICIARY_ADDRESS':g' config.local.3.toml > $TMP_FILE
 mv $TMP_FILE config.local.3.toml
 
 printf "${LOG_START}Creating storage directories...${LOG_END}"


### PR DESCRIPTION
`E2E tests / Locally` workflow was failing due to incorrect syntax of `sed`
command in the install script for `keep-ecdsa` and due to too old version
of Go installed on the virtual machine. 

More context:

Syntax of the `sed -i` command is different for MacOS and for GNU
systems. The command in its old shape was failing when run on Ubuntu
(during execution of workflow with E2E tests). Fixed by merging the
problematic command with another sed command in the same file replacing
the text by using temporary file (instead of replacing in the current
file).

We're upgrading version of Go used in E2E tests local scripts to 1.16.6.
With previously used version building of keep-ecdsa client was failing
with `note: module requires Go 1.16` error.
It turned out that just changing the version of Go in the
`install-go.sh` script was not sufficient, we had to rework the way
we're installing Go.
With previous way of installing Go, the 1.15.13 version was always used,
no matter what version was specified in the `install-go.sh` script. This
likely was caused by the fact that Go 1.14.15, 1.15.13 and 1.16.5 are
the cached tools of the `ubuntu-latest` virtual environment.
We are now switching to use of the `setup-go` action to force using of
1.16 version of Go.