### PR TITLE
Incorporate coverage pools in local-setup

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "relays"]
 	path = relays
 	url = https://github.com/keep-network/relays.git
+[submodule "coverage-pools"]
+	path = coverage-pools
+	url = https://github.com/keep-network/coverage-pools.git

--- a/deployments/local-setup-environment/provisioning/install-nodejs.sh
+++ b/deployments/local-setup-environment/provisioning/install-nodejs.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-echo "Installing Node.js and NPM..."
+echo "Installing Node.js, NPM and Yarn..."
 
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
 
@@ -14,8 +14,10 @@ nvm install 14.3.0
 nvm install 11.15.0
 nvm alias default 11.15.0
 nvm use default
+npm install --global yarn
 
 if ! [ -x "$(command -v node)" ]; then echo "Node installation failed"; exit 1; fi
 if ! [ -x "$(command -v npm)" ]; then echo "NPM installation failed"; exit 1; fi
+if ! [ -x "$(command -v yarn)" ]; then echo "NPM installation failed"; exit 1; fi
 
-echo "Node.js and NPM have been installed successfully!"
+echo "Node.js, NPM and Yarn have been installed successfully!"

--- a/docs/manual-setup.adoc
+++ b/docs/manual-setup.adoc
@@ -5,7 +5,7 @@ If you’re on macOS, install Homebrew and https://github.com/keep-network/keep-
 
 If you are not on macOS or you don't have Homebrew, you need to install:
 
-- Go compiler, at least 1.14
+- Go compiler, at least 1.16
 - Geth (Ethereum client) 1.10.3-stable
 - Solidity, at least 0.5.17
 - Protobuf compiler, at least 3.11.4

--- a/docs/manual-setup.adoc
+++ b/docs/manual-setup.adoc
@@ -15,6 +15,7 @@ If you are not on macOS or you don't have Homebrew, you need to install:
 Regardless you use `macos-setup.sh` or not, you should also install:
 
 - https://docs.docker.com/get-docker[Docker] & https://docs.docker.com/compose/install/[Docker Compose]
+- https://classic.yarnpkg.com/en/docs/install[Yarn]
 - https://github.com/pyenv/pyenv[pyenv], at least 1.2.18 (optional - only if testnet relay is used)
 - https://github.com/pypa/pipenv[pipenv], at least 2018.11.26 (optional - only if testnet relay is used)
 
@@ -67,13 +68,24 @@ $ ./run-bitcoin.sh
 $ ./install.sh
 ```
 +
-This script will fetch `keep-core`, `keep-ecdsa`, and `tbtc` source code, deploy contracts of `keep-core`, `keep-ecdsa`, and `tbtc`. It will also build `keep-core` and `keep-ecdsa` off-chain clients.
+This script will fetch `keep-core`, `keep-ecdsa`, `tbtc` and `coverage-pools`
+source code, deploy contracts of `keep-core`, `keep-ecdsa`, `tbtc` and
+`coverage-pools`. It will also build `keep-core` and `keep-ecdsa` off-chain clients.
 +
-Later on, if you decide to update `tbtc`, you can run just `install-tbtc.sh`.
+Keep in mind that `coverage-pools` depend on `tbtc`, `tbtc` depends on
+`keep-ecdsa` and `keep-ecdsa` depends on `keep-core`.
 +
-Keep in mind, `tbtc` depends on `keep-ecdsa` and `keep-ecdsa` depends on `keep-core` so if you decide to update `keep-ecdsa`, you can run `install-keep-ecdsa.sh` followed by `install-tbtc.sh`.
+If you decide to update `coverage-pools`, you can run `install-coverage-pools.sh`.
 +
-If you decide to update `keep-core`, you have to run `install-keep-core.sh` followed by `install-keep-ecdsa.sh` followed by `install-tbtc.sh` or just the entire `install.sh` again.
+If you decide to update `tbtc`, you can run `install-tbtc.sh` followed by
+`install-coverage-pools.sh`.
++
+If you decide to update `keep-ecdsa`, you can run `install-keep-ecdsa.sh`
+followed by `install-tbtc.sh` and `install-coverage-pools.sh`.
++
+If you decide to update `keep-core`, you have to run `install-keep-core.sh`
+followed by `install-keep-ecdsa.sh` followed by `install-tbtc.sh` followed by
+`install-coverage-pools.sh` or just run the entire `install.sh` again.
 
 == Run clients
 The above installation script will configure:

--- a/install-applications.sh
+++ b/install-applications.sh
@@ -11,6 +11,9 @@ set -e
 # Install tBTC.
 ./install-tbtc.sh
 
+# Install Coverage Pools.
+./install-coverage-pools.sh
+
 # Install tBTC dApp.
 ./install-tbtc-dapp.sh
 

--- a/install-coverage-pools.sh
+++ b/install-coverage-pools.sh
@@ -11,7 +11,20 @@ WORKDIR=$PWD
 
 printf "${LOG_START}Starting coverage-pools deployment...${LOG_END}"
 
-cd coverage-pools
+printf "${LOG_START}Linking dependencies...${LOG_END}"
+
+cd "$WORKDIR/keep-core/solidity"
+yarn link
+
+cd "$WORKDIR/tbtc/solidity"
+yarn link
+
+cd "$WORKDIR/coverage-pools"
+
+# Remove node modules for clean installation
+rm -rf ./node_modules
+
+printf "${LOG_START}Running install script...${LOG_END}"
 
 # Run coverage-pools install script.
 ./scripts/install.sh

--- a/install-coverage-pools.sh
+++ b/install-coverage-pools.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+LOG_START='\n\e[1;36m' # new line + bold + color
+LOG_END='\n\e[0m' # new line + reset color
+DONE_START='\n\e[1;32m' # new line + bold + green
+DONE_END='\n\n\e[0m'    # new line + reset
+
+WORKDIR=$PWD
+
+printf "${LOG_START}Starting coverage-pools deployment...${LOG_END}"
+
+cd coverage-pools
+
+# Run coverage-pools install script.
+./scripts/install.sh
+
+printf "${DONE_START}coverage-pools deployed successfully!${DONE_END}"


### PR DESCRIPTION
A script intalling coverage pools as part of installation of the system
has been added, because coverage pools are now required for successful
setup of the Token Dashboard.
A `coverage-pools` submodule needed to be added as part of this work.