### PR TITLE
Rename KEEP_TEST_ETH_HOSTNAME env variable

### DIFF
--- a/.github/workflows/e2e-testnet.yml
+++ b/.github/workflows/e2e-testnet.yml
@@ -38,8 +38,8 @@ jobs:
       - name: Run e2e tests
         run: |
           ./e2e-test.js \
-            --bitcoin-electrum-host=${{ secrets.KEEP_TEST_ELECTRUMX_HOSTNAME_WS }} \
+            --bitcoin-electrum-host=${{ secrets.KEEP_TEST_ELECTRUMX_HOSTNAME }} \
             --bitcoin-electrum-port=${{ secrets.KEEP_TEST_ELECTRUMX_PORT }} \
             --bitcoin-network="testnet" \
-            --ethereum-node=${{ secrets.KEEP_TEST_ETH_HOSTNAME }} \
+            --ethereum-node=${{ secrets.KEEP_TEST_ETH_HOSTNAME_WS }} \
             --lot-size-satoshis="1000000"

--- a/.github/workflows/e2e-testnet.yml
+++ b/.github/workflows/e2e-testnet.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Run e2e tests
         run: |
           ./e2e-test.js \
-            --bitcoin-electrum-host=${{ secrets.KEEP_TEST_ELECTRUMX_HOSTNAME }} \
+            --bitcoin-electrum-host=${{ secrets.KEEP_TEST_ELECTRUMX_HOSTNAME_WS }} \
             --bitcoin-electrum-port=${{ secrets.KEEP_TEST_ELECTRUMX_PORT }} \
             --bitcoin-network="testnet" \
             --ethereum-node=${{ secrets.KEEP_TEST_ETH_HOSTNAME }} \


### PR DESCRIPTION
We've changed the names of the secrets and need to update the workflow
configs accordingly. The change of secret name was introduced to
differentiate between WS and HTTP urls.

Depends on:
https://github.com/keep-network/local-setup/pull/98

Refs:
* https://github.com/keep-network/keep-core/pull/2548
*  https://github.com/keep-network/keep-ecdsa/pull/872
* https://github.com/keep-network/tbtc/pull/818