### PR TITLE
No longer install `sha3` in a separate step

### DIFF
--- a/docs/manual-setup.adoc
+++ b/docs/manual-setup.adoc
@@ -236,8 +236,6 @@ Confirm all of the transactions and verify that the TBTC has left your wallet. Y
 
 * If you're getting an error initiating the deposit, try resetting your wallet in metamask
   (top right -> Settings -> Advanced -> Reset Account)
-* During the keep-ecdsa phase of running install.sh it may complain about sha3.
-  If that happens, cd into keep-ecdsa and run: `$ npm install --save-dev sha3`
 * If you see an error coming from npm complaining about dependencies (e.g. babel-cli),
   try deleting `package-lock.json` (e.g. if npm cannot find file
   `local-setup/tbtc/solidity/node_modules/.staging/@keep-network/keep-ecdsa-64660964/node_modules/@babel/cli`,

--- a/install-e2e-test.sh
+++ b/install-e2e-test.sh
@@ -6,18 +6,8 @@ echo "Running npm install..."
 cd e2e
 npm install
 
-# Without the below step with installation of the `sha3`, the later step with
-# `npm link` in `keep-ecdsa/solidity` fails with the following error:
-# ```
-# npm ERR! Failed at the sha3@1.2.3 install script.
-# npm ERR! This is probably not a problem with npm. There is likely
-# additional logging output above.
-# ```
-cd ../keep-ecdsa/solidity
-npm install --save-dev sha3
-
 echo "Linking..."
-cd ../../keep-core/solidity
+cd ../keep-core/solidity
 npm link
 cd ../../keep-ecdsa/solidity
 npm link


### PR DESCRIPTION
Up until recently, the `package-lock.json` in `keep-ecdsa/solidity` had
the `sha3` package configured in the `1.2.3` version. This version
wasn't working correctly with the Node.js 14.x which we're using for E2E
testing. This meant we needed to upgrade the `sha3` to a higher version.
Previously we've been doing that in the `install-e2e-test.sh` script,
but recently we upgraded the version (to `1.2.6`) directly in the
`keep-ecdsa/solidity/package-lock.json` file, making the `npm install
--save-dev sha3` step in the `install-e2e-test.sh` script obsolete.

Ref: https://github.com/keep-network/keep-ecdsa/pull/878