### PR TITLE
Remove rpc.allow-unprotected-txs for geth

### DIFF
--- a/run-geth.sh
+++ b/run-geth.sh
@@ -22,6 +22,5 @@ geth --port 0 --networkid 1101 --identity "somerandomidentity" \
     --miner.etherbase=$GETH_ETHEREUM_ACCOUNT --mine --miner.threads=1 \
     --unlock $GETH_ETHEREUM_ACCOUNT --password <(echo "password") \
     --allow-insecure-unlock \
-    --rpc.allow-unprotected-txs \
     --snapshot=false \
     --nodiscover --maxpeers 0


### PR DESCRIPTION
The flag should not be set if we want to handle EIP155 transactions correctly.
This PR is a follow-up after https://github.com/keep-network/local-setup/pull/114.