### PR TITLE
Adding cron for daily tests and builds on Mercode

### DIFF
--- a/.github/workflows/bitcoin.yml
+++ b/.github/workflows/bitcoin.yml
@@ -1,6 +1,8 @@
 name: bitcoin
 
 on:
+  schedule:
+    - cron: '0 0 * * *'
   push:
     branches:
       - main

--- a/.github/workflows/common-js.yml
+++ b/.github/workflows/common-js.yml
@@ -1,6 +1,8 @@
 name: common.js
 
 on:
+  schedule:
+    - cron: '0 0 * * *'
   push:
     branches:
       - main
@@ -53,6 +55,7 @@ jobs:
     if: |
       github.event_name != 'pull_request'
         || needs.common-js-detect-changes.outputs.path-filter == 'true'
+        || github.event_name != 'schedule'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/common-js.yml
+++ b/.github/workflows/common-js.yml
@@ -53,9 +53,9 @@ jobs:
   common-js-lint:
     needs: common-js-detect-changes
     if: |
-      github.event_name != 'pull_request'
+      (github.event_name != 'pull_request'
+        && github.event_name != 'schedule')
         || needs.common-js-detect-changes.outputs.path-filter == 'true'
-        || github.event_name != 'schedule'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
The purpose of this PR is to set a cron job that would run tests and builds on a daily basis (at midnight) so the results can be displayed on Meercode dashboard.