### PR TITLE
Removing cron for bitcoin external libs

### DIFF
--- a/.github/workflows/bitcoin.yml
+++ b/.github/workflows/bitcoin.yml
@@ -1,8 +1,6 @@
 name: bitcoin
 
 on:
-  schedule:
-    - cron: '0 0 * * *'
   push:
     branches:
       - main


### PR DESCRIPTION
We do not need to validate external libs in daily builds. External libs should be compiled properly.