### PR TITLE
Bump up Node.js version used in the 'E2E / Locally' workflow to 14.17.0

### DIFF
--- a/.github/workflows/e2e-local.yml
+++ b/.github/workflows/e2e-local.yml
@@ -18,10 +18,10 @@ jobs:
         working-directory: ./deployments/local-setup-environment/provisioning/
         run: ./install-commons.sh
 
-      - name: Use Node.js 12
+      - name: Use Node.js 14.17.0
         uses: actions/setup-node@v2
         with:
-          node-version: "12"
+          node-version: "14.17.0"
 
       - name: Cache node modules
         uses: actions/cache@v2
@@ -81,11 +81,6 @@ jobs:
           ./run-ecdsa-1.sh &
           ./run-ecdsa-2.sh &
           ./run-ecdsa-3.sh &
-
-      - name: Use Node.js 14.17.0
-        uses: actions/setup-node@v2
-        with:
-          node-version: "14.17.0"
 
       - name: Prepare environment for running E2E test scripts
         run: ./install-e2e-test.sh

--- a/.github/workflows/e2e-local.yml
+++ b/.github/workflows/e2e-local.yml
@@ -22,18 +22,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: "14"
-
-      - name: Cache node modules
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-solidity-node-modules
-        with:
-          path: ~/.npm # npm cache files are stored in `~/.npm` on Linux/macOS
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
+          cache: "npm"
 
       - name: Set up Go 1.16
         uses: actions/setup-go@v1

--- a/.github/workflows/e2e-local.yml
+++ b/.github/workflows/e2e-local.yml
@@ -18,10 +18,10 @@ jobs:
         working-directory: ./deployments/local-setup-environment/provisioning/
         run: ./install-commons.sh
 
-      - name: Use Node.js 14.17.0
+      - name: Use Node.js 14
         uses: actions/setup-node@v2
         with:
-          node-version: "14.17.0"
+          node-version: "14"
 
       - name: Cache node modules
         uses: actions/cache@v2


### PR DESCRIPTION
Previously for part of the workflow we were using Node.js in version 12
and for part - version 14.17.0. Version 12 was needed because some of
the installed subprojects were built using v12. Now all subprojects are
built using v14, so we can use one common v14 for the whole workflow
with e2e tests.