### PR TITLE
Update scripts after moving keep-core random beacon to `solidity-v1`

### DIFF
--- a/install-coverage-pools.sh
+++ b/install-coverage-pools.sh
@@ -13,7 +13,7 @@ printf "${LOG_START}Starting coverage-pools deployment...${LOG_END}"
 
 printf "${LOG_START}Linking dependencies...${LOG_END}"
 
-cd "$WORKDIR/keep-core/solidity"
+cd "$WORKDIR/keep-core/solidity-v1"
 yarn link
 
 cd "$WORKDIR/tbtc/solidity"

--- a/install-e2e-test.sh
+++ b/install-e2e-test.sh
@@ -7,7 +7,7 @@ cd e2e
 npm install
 
 echo "Linking..."
-cd ../keep-core/solidity
+cd ../keep-core/solidity-v1
 npm link
 cd ../../keep-ecdsa/solidity
 npm link

--- a/install-keep-dashboard.sh
+++ b/install-keep-dashboard.sh
@@ -13,7 +13,7 @@ printf "${LOG_START}Starting Keep Dashboard deployment...${LOG_END}"
 
 printf "${LOG_START}Preparing keep-core artifacts...${LOG_END}"
 
-cd $WORKDIR/keep-core/solidity
+cd $WORKDIR/keep-core/solidity-v1
 ln -sf build/contracts artifacts
 
 printf "${LOG_START}Preparing keep-ecdsa artifacts...${LOG_END}"
@@ -28,13 +28,13 @@ ln -sf build/contracts artifacts
 
 printf "${LOG_START}Install Keep Dashboard dependencies...${LOG_END}"
 
-cd $WORKDIR/keep-core/solidity/dashboard
+cd $WORKDIR/keep-core/solidity-v1/dashboard
 
 npm install
 
 printf "${LOG_START}Updating Keep Dashboard dependencies...${LOG_END}"
 
-cd $WORKDIR/keep-core/solidity
+cd $WORKDIR/keep-core/solidity-v1
 npm link
 
 cd $WORKDIR/keep-ecdsa/solidity
@@ -45,7 +45,7 @@ npm link
 
 printf "${LOG_START}Updating Keep Dashboard configuration...${LOG_END}"
 
-cd $WORKDIR/keep-core/solidity/dashboard
+cd $WORKDIR/keep-core/solidity-v1/dashboard
 npm link @keep-network/keep-core @keep-network/keep-ecdsa @keep-network/tbtc
 
 printf "${DONE_START}Keep Dashboard initialized successfully!${DONE_END}"

--- a/install-keep-ecdsa.sh
+++ b/install-keep-ecdsa.sh
@@ -55,7 +55,7 @@ mv $TMP_FILE truffle.js
 
 printf "${LOG_START}Linking dependencies...${LOG_END}"
 
-cd "$WORKDIR/keep-core/solidity"
+cd "$WORKDIR/keep-core/solidity-v1"
 npm link
 
 printf "${LOG_START}Running install script...${LOG_END}"

--- a/install-tbtc.sh
+++ b/install-tbtc.sh
@@ -43,7 +43,7 @@ printf "${LOG_START}Running install script...${LOG_END}"
 
 printf "${LOG_START}Linking dependencies...${LOG_END}"
 
-cd "$WORKDIR/keep-core/solidity"
+cd "$WORKDIR/keep-core/solidity-v1"
 npm link
 
 cd "$WORKDIR/keep-ecdsa/solidity"

--- a/run-keep-dashboard.sh
+++ b/run-keep-dashboard.sh
@@ -11,6 +11,6 @@ WORKDIR=$PWD
 
 printf "${LOG_START}Starting Keep Dashboard...${LOG_END}"
 
-cd $WORKDIR/keep-core/solidity/dashboard
+cd $WORKDIR/keep-core/solidity-v1/dashboard
 
 npm run start


### PR DESCRIPTION
There was a change in `keep-core`, in which random beacon and token
dashboard -related code was moved from `solidity/` to `solidity-v1/`
folder, as a result of decision to change the code structure before
introduction of random beacon v2.
We need to update `local-setup` scripts which reference the moved code.