### PR TITLE
Unify CI workflows

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 jobs:
   code-format:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: "14.x"
+          cache: "yarn"
 
       - name: Install dependencies
         run: yarn install


### PR DESCRIPTION
We have CI workflows scattered across various repositories. We try to keep their implementation as similar as possible. In this PR and the ones listed below we introduce a couple of changes which unify used solutions and fix small mistakes, such as:
* making tagging of published packages consistent
* passing `NPM_TOKEN` secret as variable instead of passing it by writing to file
* handling caching of npm/yarn dependencies via `setup-node` action
* adding `workflow_dispatch` job trigger where it's missing
* using Node.js in version 14.x instead of 12.x where possible

Related PRs in other repositories:
* https://github.com/keep-network/keep-core/pull/2776
* https://github.com/keep-network/keep-ecdsa/pull/941
* https://github.com/keep-network/tbtc/pull/842
* https://github.com/keep-network/tbtc.js/pull/145
* https://github.com/keep-network/sortition-pools/pull/145
* https://github.com/keep-network/coverage-pools/pull/204
* https://github.com/keep-network/tbtc-v2/pull/88
* https://github.com/threshold-network/solidity-contracts/pull/59