### PR TITLE
Increase amount of coins for covering the fee

### DIFF
--- a/e2e/common.js
+++ b/e2e/common.js
@@ -68,10 +68,10 @@ export const sendBitcoinTransaction = async (
 
   // Start from the oldest UTXO.
   for (const utxo of utxos.reverse()) {
-    // Make sure the selected coins amount covers the 120% of the amount.
-    // The additional 20% is taken as a big reserve to make sure that input
+    // Make sure the selected coins amount covers the 130% of the amount.
+    // The additional 30% is taken as a big reserve to make sure that input
     // coins will cover the transaction fee.
-    if (coinsAmount >= 1.2 * amount.toNumber()) {
+    if (coinsAmount >= 1.3 * amount.toNumber()) {
       break
     }
 


### PR DESCRIPTION
With previous factor (`1.2`) E2E tests on Ropsten testnet were failing
with `undingError: Not enough funds. (available=0.0001236,
required=0.0001276)` error. In this commit we increase the factor to
`1.3` - with that value error is no longer occurring.

Closes #127.