### PR TITLE
Checkout specific SHA of cov-pools during installation of repositories

### DIFF
--- a/install-repositories.sh
+++ b/install-repositories.sh
@@ -8,3 +8,11 @@ LOG_END='\n\e[0m'      # new line + reset color
 printf "${LOG_START}Initializing submodules...${LOG_END}"
 
 git submodule update --init --recursive --remote --rebase --force
+
+# We need to checkout `coverage-pools` at `6a9b084`, as after that commit we
+# introduced in the the `Asset Pool` contract a call to a `delegate` function
+# which is not present in the `KeepToken` contract used during `AssetPool`'s
+# deployment script.
+cd coverage-pools
+git checkout 6a9b0840e3b79e58f4f25892d5b8ac853fabc62e
+cd ..

--- a/install-repositories.sh
+++ b/install-repositories.sh
@@ -9,10 +9,11 @@ printf "${LOG_START}Initializing submodules...${LOG_END}"
 
 git submodule update --init --recursive --remote --rebase --force
 
-# We need to checkout `coverage-pools` at `6a9b084`, as after that commit we
-# introduced in the the `Asset Pool` contract a call to a `delegate` function
-# which is not present in the `KeepToken` contract used during `AssetPool`'s
-# deployment script.
+# We need to stay at commit `6a9b084` which is right before the `AssetPool`
+# contract took a new collateral token with a `delegate()` function. Coverage
+# pool utilizes Keep Token which does not have a `delegate()`` function. If the
+# latest code is used for coverage pools, then the CI will break during the
+# deployment of the `AssetPool` contract.
 cd coverage-pools
 git checkout 6a9b0840e3b79e58f4f25892d5b8ac853fabc62e
 cd ..


### PR DESCRIPTION
We need to checkout `coverage-pools` at `6a9b084`, as after that commit
we introduced in the the `Asset Pool` contract a call to a `delegate`
function which is not present in the `KeepToken` contract used during
`AssetPool`'s deployment script.
Using latest code from `main` was causing error in the E2E tests on
local env., at the stage of running `05_deploy_asset_pool.ts` script
during installation of `coverage-pools`. Error was misleadingly
suggesting problems with gas estimation (`cannot estimate gas;
transaction may fail or may require manual gas limit`).

More details about the root cause:
- in PR 206 we introduced `delegate` function in `ICollateralToken`
https://github.com/keep-network/coverage-pools/blob/main/contracts/interfaces/ICollateralToken.sol#L30
- in the deployment script `00_resolve_keep_token.ts`  KeepToken is used
from the dependencies set in `package.json`, which does not have a
`delegate` function
https://github.com/keep-network/coverage-pools/blob/main/deploy/00_resolve_keep_token.ts#L12
- AssetPool uses KeepToken in its deployment script:
https://github.com/keep-network/coverage-pools/blob/main/deploy/05_deploy_asset_pool.ts#L14
- KeepToken is passed to the Asset Pool constructor as a collateral
token and tries to call a `delegate` function which doesn't exist
https://github.com/keep-network/coverage-pools/blob/main/contracts/AssetPool.sol#L155

Workflow with E2E tests run on the feature branch: https://github.com/keep-network/local-setup/actions/runs/1817475780

Refs:
https://github.com/keep-network/keep-core/pull/2818