### PR TITLE
Increase frequency of running E2E tests on Testnet

### DIFF
--- a/.github/workflows/e2e-testnet.yml
+++ b/.github/workflows/e2e-testnet.yml
@@ -2,7 +2,7 @@ name: E2E tests / Testnet
 
 on:
   schedule:
-    - cron: "0 */6 * * *"
+    - cron: "0 */2 * * *"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
After fixing some other issue causing E2E tests to fail we observed
that the test were still failing, this time with `execution reverted:
not at current or previous difficulty` error.
This is an error which we have seen in the past, happening for around
60% of jobs. Now we're seeing it for 100% of jobs, but we haven't run
many jobs so far since fixing that other issue. We want to increase the
frequency of tests execution to see if we will get some passing jobs
apart from those which fail.