### PR TITLE
Don't use unauthenticated git protocol

### DIFF
--- a/.github/workflows/e2e-local.yml
+++ b/.github/workflows/e2e-local.yml
@@ -71,6 +71,14 @@ jobs:
           ./run-ecdsa-2.sh &
           ./run-ecdsa-3.sh &
 
+      # We need this step because the `@keep-network/tbtc.js` which we update in
+      # next step has an indirect dependency to `@summa-tx/relay-sol@2.0.2`
+      # package, which downloads one of its sub-dependencies via unathenticated
+      # `git://` protocol. That protocol is no longer supported. Thanks to this
+      # step `https://` is used instead of `git://`.
+      - name: Configure git to don't use unauthenticated protocol
+        run: git config --global url."https://".insteadOf git://
+        
       - name: Prepare environment for running E2E test scripts
         run: ./install-e2e-test.sh
 

--- a/.github/workflows/e2e-testnet.yml
+++ b/.github/workflows/e2e-testnet.yml
@@ -20,6 +20,14 @@ jobs:
           cache: "npm"
           cache-dependency-path: e2e/package-lock.json
 
+      # We need this step because the `@keep-network/tbtc.js` which we update in
+      # next step has an indirect dependency to `@summa-tx/relay-sol@2.0.2`
+      # package, which downloads one of its sub-dependencies via unathenticated
+      # `git://` protocol. That protocol is no longer supported. Thanks to this
+      # step `https://` is used instead of `git://`.
+      - name: Configure git to don't use unauthenticated protocol
+        run: git config --global url."https://".insteadOf git://
+
       - run: npm install --save-exact @keep-network/tbtc.js@ropsten
 
       - name: Run e2e tests

--- a/docs/manual-setup.adoc
+++ b/docs/manual-setup.adoc
@@ -256,6 +256,12 @@ Confirm all of the transactions and verify that the TBTC has left your wallet. Y
 * If you pressed "Deposit" and got Unhandled Rejection error from dApp, make sure
   the wallet is connected to your local ethereum network (in metamask go to
   My Accounts->Settings->Networks, Chain Id for localhost:8545 should be 1101).
+* If you see `The unauthenticated git protocol on port 9418 is no longer
+  supported` error or erors like  `ENOENT: no such file or directory, open
+  '/home/runner/work/local-setup/local-setup/e2e/node_modules/.staging/...'`,
+  you can change Git configuration on your local enviroment to always use
+  `https://` protocol instaed of `git://` to download files. This can be done by
+  executing command: `git config --global url."https://".insteadOf git://`
 
 === E2E tests
 


### PR DESCRIPTION
The `tbtc.js` package contains a dependency to `@summa-tx/relay-sol@2.0.2`
package, which downloads one of its sub-dependencies via unathenticated
`git://` protocol. That protocol is no longer supported by GitHub. This
means that in certain situations installation of the package or update
of its dependencies using NPM may result in `The unauthenticated git
protocol on port 9418 is no longer supported` error or errors like
`ENOENT: no such file or directory, open
'/home/runner/work/local-setup/local-setup/e2e/node_modules/.staging/...'`.
That what was happening during execution of `e2e-local.yml` and
`e2e-testnet.yml. workflows.

As a workaround, we're adding to workflows a step which configures
Git to use `https://` protocol instead of `git://` when downloading
files.

More info:
https://github.blog/2021-09-01-improving-git-protocol-security-github/.