### PR TITLE
Decrease frequency of `e2e-testnet` workflow execution

### DIFF
--- a/.github/workflows/e2e-local.yml
+++ b/.github/workflows/e2e-local.yml
@@ -78,7 +78,7 @@ jobs:
       # step `https://` is used instead of `git://`.
       - name: Configure git to don't use unauthenticated protocol
         run: git config --global url."https://".insteadOf git://
-        
+
       - name: Prepare environment for running E2E test scripts
         run: ./install-e2e-test.sh
 

--- a/.github/workflows/e2e-testnet.yml
+++ b/.github/workflows/e2e-testnet.yml
@@ -2,7 +2,7 @@ name: E2E tests / Testnet
 
 on:
   schedule:
-    - cron: "0 */2 * * *"
+    - cron: "0 */6 * * *"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Some time ago we temporarily increased frequency of workflow execution
from "every 6 hours" to "every 2 hours". We did that to have better
statistics of percentage of failing jobs. Now we have a good view and
can bring the frequency to original values.