### PR TITLE
Cleanup of v1-related GH Actions workflows

### DIFF
--- a/.github/workflows/common-js.yml
+++ b/.github/workflows/common-js.yml
@@ -1,8 +1,6 @@
 name: common.js
 
 on:
-  schedule:
-    - cron: "0 0 * * *"
   push:
     branches:
       - main

--- a/.github/workflows/e2e-local.yml
+++ b/.github/workflows/e2e-local.yml
@@ -1,8 +1,6 @@
 name: E2E tests / Locally
 
 on:
-  schedule:
-    - cron: "0 0 * * *"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/e2e-testnet.yml
+++ b/.github/workflows/e2e-testnet.yml
@@ -1,8 +1,6 @@
 name: E2E tests / Testnet
 
 on:
-  schedule:
-    - cron: "0 */6 * * *"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
The workflows that we're modifying in this PR were related to the `v1` of the system, which is no longer getting new functionalities. We don't need to execute these workflows every night / couple of hours.