### PR TITLE
Update actions to versions running on Node20

### DIFF
--- a/.github/workflows/bitcoin-bitcoind.yml
+++ b/.github/workflows/bitcoin-bitcoind.yml
@@ -15,9 +15,9 @@ jobs:
     outputs:
       path-filter: ${{ steps.filter.outputs.path-filter }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         if: github.event_name == 'pull_request'
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@v3
         if: github.event_name == 'pull_request'
         id: filter
         with:
@@ -35,13 +35,13 @@ jobs:
       run:
         working-directory: ./bitcoin/bitcoind
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -50,14 +50,14 @@ jobs:
 
       - name: Login to GitHub Container Registry
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and Publish Docker Image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         env:
           IMAGE_NAME: ghcr.io/keep-network/local-setup/bitcoind
         with:

--- a/.github/workflows/bitcoin-electrs.yml
+++ b/.github/workflows/bitcoin-electrs.yml
@@ -15,9 +15,9 @@ jobs:
     outputs:
       path-filter: ${{ steps.filter.outputs.path-filter }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         if: github.event_name == 'pull_request'
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@v3
         if: github.event_name == 'pull_request'
         id: filter
         with:
@@ -35,13 +35,13 @@ jobs:
       run:
         working-directory: ./bitcoin/electrs
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -50,14 +50,14 @@ jobs:
 
       - name: Login to GitHub Container Registry
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and Publish Docker Image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         env:
           IMAGE_NAME: ghcr.io/keep-network/local-setup/electrs
         with:

--- a/.github/workflows/bitcoin-electrumx.yml
+++ b/.github/workflows/bitcoin-electrumx.yml
@@ -15,9 +15,9 @@ jobs:
     outputs:
       path-filter: ${{ steps.filter.outputs.path-filter }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         if: github.event_name == 'pull_request'
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@v3
         if: github.event_name == 'pull_request'
         id: filter
         with:
@@ -35,13 +35,13 @@ jobs:
       run:
         working-directory: ./bitcoin/electrumx
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -50,14 +50,14 @@ jobs:
 
       - name: Login to GitHub Container Registry
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and Publish Docker Image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         env:
           IMAGE_NAME: ghcr.io/keep-network/local-setup/electrumx
         with:

--- a/.github/workflows/bitcoin-esplora.yml
+++ b/.github/workflows/bitcoin-esplora.yml
@@ -15,9 +15,9 @@ jobs:
     outputs:
       path-filter: ${{ steps.filter.outputs.path-filter }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         if: github.event_name == 'pull_request'
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@v3
         if: github.event_name == 'pull_request'
         id: filter
         with:
@@ -35,13 +35,13 @@ jobs:
       run:
         working-directory: ./bitcoin/esplora
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -50,14 +50,14 @@ jobs:
 
       - name: Login to GitHub Container Registry
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and Publish Docker Image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         env:
           IMAGE_NAME: ghcr.io/keep-network/local-setup/esplora
         with:

--- a/.github/workflows/common-js.yml
+++ b/.github/workflows/common-js.yml
@@ -19,9 +19,9 @@ jobs:
     outputs:
       path-filter: ${{ steps.filter.outputs.path-filter }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         if: github.event_name == 'pull_request'
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@v3
         if: github.event_name == 'pull_request'
         id: filter
         with:
@@ -36,9 +36,9 @@ jobs:
         || needs.common-js-detect-changes.outputs.path-filter == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: "12.x"
 
@@ -56,9 +56,9 @@ jobs:
         || needs.common-js-detect-changes.outputs.path-filter == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: "12.x"
 
@@ -82,9 +82,9 @@ jobs:
   #       && github.event_name != 'pull_request'
   #   runs-on: ubuntu-latest
   #   steps:
-  #     - uses: actions/checkout@v2
+  #     - uses: actions/checkout@v4
 
-  #     - uses: actions/setup-node@v2
+  #     - uses: actions/setup-node@v4
   #       with:
   #         node-version: "12.x"
 

--- a/.github/workflows/e2e-local.yml
+++ b/.github/workflows/e2e-local.yml
@@ -10,20 +10,20 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Install common tools
         working-directory: ./deployments/local-setup-environment/provisioning/
         run: ./install-commons.sh
 
       - name: Use Node.js 14
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: "14"
           cache: "npm"
 
       - name: Set up Go 1.16
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v5
         with:
           go-version: 1.16
 

--- a/.github/workflows/e2e-testnet.yml
+++ b/.github/workflows/e2e-testnet.yml
@@ -10,9 +10,9 @@ jobs:
       run:
         working-directory: ./e2e
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: "14.x"
           cache: "npm"

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -11,9 +11,9 @@ jobs:
   code-format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: "14.x"
           cache: "yarn"


### PR DESCRIPTION
As per
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/, GitHub has started a deprecation process for the GitHub Actions that run on Node16. We're updating Actions that use this version of Node to newer versions, running on Node20.